### PR TITLE
fix: use user-scoped endpoint for listing channels

### DIFF
--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -424,7 +424,10 @@ class MattermostClient:
         page: int = 0,
         per_page: int = 60,
     ) -> list[dict[str, Any]]:
-        """Get public channels in a team.
+        """Get channels the authenticated user belongs to in a team.
+
+        Returns public, private, DM, and group DM channels
+        where the current user is a member.
 
         Args:
             team_id: Team identifier
@@ -435,7 +438,7 @@ class MattermostClient:
             List of channel objects
         """
         result = await self.get(
-            f"/teams/{team_id}/channels",
+            f"/users/me/teams/{team_id}/channels",
             params={"page": page, "per_page": per_page},
         )
         return result if isinstance(result, list) else []

--- a/src/mcp_server_mattermost/tools/channels.py
+++ b/src/mcp_server_mattermost/tools/channels.py
@@ -23,10 +23,10 @@ async def list_channels(
     per_page: Annotated[int, Field(ge=1, le=200, description="Results per page")] = 60,
     client: MattermostClient = Depends(get_client),  # noqa: B008
 ) -> list[Channel]:
-    """List public and private channels in a team.
+    """List channels the authenticated user belongs to in a team.
 
-    Returns channels that the authenticated user has access to.
-    Use this to discover available channels for posting messages.
+    Returns public, private, DM, and group DM channels where you are a member.
+    Use this to discover your available channels for posting messages.
     """
     data = await client.get_channels(
         team_id=team_id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -790,7 +790,7 @@ class TestMattermostClientChannelsAPI:
         settings = get_settings()
         client = MattermostClient(settings)
 
-        route = respx.get("https://test.mattermost.com/api/v4/teams/team123/channels").mock(
+        route = respx.get("https://test.mattermost.com/api/v4/users/me/teams/team123/channels").mock(
             return_value=httpx.Response(200, json=[{"id": "ch123", "name": "general"}]),
         )
 


### PR DESCRIPTION
Switch list_channels from /teams/{team_id}/channels (public only, requires admin for private) to /users/me/teams/{team_id}/channels which returns all channel types (public, private, DM, group DM) the authenticated user is a member of. This matches the expected behavior for bot/user tokens.

## What Changed

<!-- Describe your changes -->

## Related Issue

<!-- Link to issue: Fixes #123 -->

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Linter passes (`uv run ruff check src tests`)
- [ ] Type checker passes (`uv run mypy src`)
- [ ] Documentation updated (if applicable)
