### PR TITLE
Add Mattermost OAuth proxy auth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- New `MATTERMOST_AUTH_MODE` setting selects one of three authentication strategies per server process: `static_token` (default), `client_token`, or `oauth_proxy`.
+- `oauth_proxy` mode using FastMCP `OAuthProxy` with Mattermost OAuth 2.0 Applications. Supports both confidential and public client modes; PKCE forwarded upstream in both cases.
+- New OAuth-related settings: `MATTERMOST_OAUTH_CLIENT_ID`, `MATTERMOST_OAUTH_CLIENT_SECRET`, `MATTERMOST_OAUTH_CLIENT_TYPE`, `MATTERMOST_OAUTH_MCP_PUBLIC_URL`, `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL`, `MATTERMOST_OAUTH_CALLBACK_PATH`, `MATTERMOST_OAUTH_JWT_SIGNING_KEY`, `MATTERMOST_OAUTH_REQUIRE_CONSENT`, `MATTERMOST_OAUTH_ALLOWED_REDIRECT_URIS`, `MATTERMOST_OAUTH_FALLBACK_ACCESS_TOKEN_EXPIRY_SECONDS`.
+- New `docs/authentication.md` page covering all three auth modes, Mattermost OAuth App registration, MCP client connection, troubleshooting, and the full env-var reference.
+
+### Changed
+- The Docker image now installs the package at build time. Container startup invokes the venv binary directly instead of going through `uv run`, eliminating a redundant `uv sync` on every start.
+- **Behavioral change:** in `client_token` mode (and the new `oauth_proxy` mode), requests without a validated bearer token now fail with `AuthenticationError` instead of silently falling back to `MATTERMOST_TOKEN`. If you previously relied on the bot-token fallback for unauthenticated requests, switch to `MATTERMOST_AUTH_MODE=static_token` and remove `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS`.
+- **Behavioral change:** setting both `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS=true` and `MATTERMOST_AUTH_MODE` to a non-`client_token` value now raises a configuration error at startup. Previously the legacy flag was silently ignored when both were set with conflicting values.
+- **Behavioral change:** `mcp_server_mattermost.server` module import now performs full configuration validation eagerly. Tools or test fixtures that imported the module before configuring environment variables may need to be updated.
+
+### Deprecated
+- `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS=true` is now an alias for `MATTERMOST_AUTH_MODE=client_token`. Prefer setting `MATTERMOST_AUTH_MODE` explicitly.
+
 ## [0.4.0] - 2026-03-24
 
 ### Breaking Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,16 @@ WORKDIR /app
 
 # Optimization flags
 ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
     UV_NO_PROGRESS=1 \
     PYTHONUNBUFFERED=1
 
-# Copy dependency files first for layer caching
+# Install dependencies first (cached unless pyproject.toml/uv.lock change)
 COPY pyproject.toml uv.lock README.md ./
-COPY src ./src
+RUN uv sync --frozen --no-dev --no-install-project
 
-# Install dependencies as root (cache in /root/.cache/uv)
-# The .venv will be in /app and accessible to non-root user
+# Install the project itself (re-runs only when src/ changes)
+COPY src ./src
 RUN uv sync --frozen --no-dev
 
 # Create non-root user for security

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 # Copy dependency files first for layer caching
 COPY pyproject.toml uv.lock README.md ./
+COPY src ./src
 
 # Install dependencies as root (cache in /root/.cache/uv)
 # The .venv will be in /app and accessible to non-root user
@@ -17,9 +18,6 @@ RUN uv sync --frozen --no-dev
 # Create non-root user for security
 RUN useradd -m -u 1000 mcp && chown -R mcp:mcp /app
 USER mcp
-
-# Copy source code
-COPY --chown=mcp:mcp src ./src
 
 # Default port for HTTP mode
 EXPOSE 8000
@@ -31,4 +29,4 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=5s \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 # Default: stdio mode. Override with MCP_TRANSPORT=http
-CMD ["uv", "run", "mcp-server-mattermost"]
+CMD ["/app/.venv/bin/mcp-server-mattermost"]

--- a/README.md
+++ b/README.md
@@ -173,16 +173,10 @@ Once configured, you can ask your AI assistant:
 | `MATTERMOST_LOG_LEVEL` | No | INFO | Logging level |
 | `MATTERMOST_LOG_FORMAT` | No | json | Log output format: `json` or `text` |
 | `MATTERMOST_API_VERSION` | No | v4 | Mattermost API version |
-| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
-| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Mattermost OAuth App ID for `oauth_proxy`. |
-| `MATTERMOST_OAUTH_CLIENT_TYPE` | Conditional | `confidential` | `public` or `confidential` for `oauth_proxy`. |
-| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Required for confidential OAuth Apps. |
-| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Public base URL of this MCP server. Required for `oauth_proxy`. |
-| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects. |
-| `MATTERMOST_OAUTH_CALLBACK_PATH` | No | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App. |
-| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | Required for public OAuth Apps; optional for confidential. |
-| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | No | true | Show the FastMCP consent screen before redirecting to Mattermost. |
-| `MATTERMOST_OAUTH_FALLBACK_ACCESS_TOKEN_EXPIRY_SECONDS` | No | — | Fallback token TTL. |
+
+For `client_token` and `oauth_proxy` modes — including Mattermost OAuth App
+registration, all `MATTERMOST_OAUTH_*` settings, and MCP client connection — see
+[Authentication](docs/authentication.md).
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -165,14 +165,22 @@ Once configured, you can ask your AI assistant:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MATTERMOST_URL` | Yes | — | Mattermost server URL |
-| `MATTERMOST_TOKEN` | Conditional | — | Bot or personal access token. MATTERMOST_TOKEN is required only when per-client token authentication (MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS) is not enabled. |
+| `MATTERMOST_AUTH_MODE` | No | `static_token` | Authentication mode: `static_token`, `client_token`, or `oauth_proxy` |
+| `MATTERMOST_TOKEN` | Conditional | — | Bot or personal access token. Required only when `MATTERMOST_AUTH_MODE=static_token`. |
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |
 | `MATTERMOST_LOG_LEVEL` | No | INFO | Logging level |
 | `MATTERMOST_LOG_FORMAT` | No | json | Log output format: `json` or `text` |
 | `MATTERMOST_API_VERSION` | No | v4 | Mattermost API version |
-| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Allow HTTP clients to use their own Mattermost tokens |
+| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
+| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Mattermost OAuth App client ID. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
+| `MATTERMOST_OAUTH_CLIENT_TYPE` | Conditional | `confidential` | Mattermost OAuth App type: `public` or `confidential`. Used by `oauth_proxy`. |
+| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Mattermost OAuth App secret. Required for confidential OAuth Apps. |
+| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Public base URL of this MCP server. Required for `oauth_proxy`. |
+| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects. |
+| `MATTERMOST_OAUTH_CALLBACK_PATH` | No | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App. |
+| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | FastMCP JWT signing key. Required for public OAuth Apps, optional for confidential OAuth Apps. |
 
 ## Docker
 
@@ -218,6 +226,31 @@ docker run -d -p 8000:8000 \
 ```
 
 Health check: `curl http://localhost:8000/health`
+
+### HTTP mode with Mattermost OAuth proxy
+
+```bash
+docker run -d -p 8000:8000 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HOST=0.0.0.0 \
+  -e MATTERMOST_AUTH_MODE=oauth_proxy \
+  -e MATTERMOST_URL=https://mattermost.internal \
+  -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
+  -e MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com \
+  -e MATTERMOST_OAUTH_CLIENT_ID=your-mattermost-oauth-app-id \
+  -e MATTERMOST_OAUTH_CLIENT_TYPE=confidential \
+  -e MATTERMOST_OAUTH_CLIENT_SECRET=your-mattermost-oauth-app-secret \
+  legard/mcp-server-mattermost
+```
+
+Register the Mattermost OAuth App callback URL as:
+
+```text
+https://mcp.example.com/oauth/callback/mm
+```
+
+If your Mattermost login uses Keycloak SSO, users authenticate through Keycloak inside
+the Mattermost OAuth login flow. The MCP server does not need a Keycloak client.
 
 ### Environment Variables (Docker)
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Once configured, you can ask your AI assistant:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MATTERMOST_URL` | Yes | — | Mattermost server URL |
-| `MATTERMOST_AUTH_MODE` | No | `static_token` | Authentication mode: `static_token`, `client_token`, or `oauth_proxy` |
-| `MATTERMOST_TOKEN` | Conditional | — | Bot or personal access token. Required only when `MATTERMOST_AUTH_MODE=static_token`. |
+| `MATTERMOST_AUTH_MODE` | No | `static_token` | Auth mode: `static_token`, `client_token`, or `oauth_proxy` |
+| `MATTERMOST_TOKEN` | Conditional | — | Bot or personal token. Required for `static_token`. |
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |
@@ -174,13 +174,15 @@ Once configured, you can ask your AI assistant:
 | `MATTERMOST_LOG_FORMAT` | No | json | Log output format: `json` or `text` |
 | `MATTERMOST_API_VERSION` | No | v4 | Mattermost API version |
 | `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
-| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Mattermost OAuth App client ID. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
-| `MATTERMOST_OAUTH_CLIENT_TYPE` | Conditional | `confidential` | Mattermost OAuth App type: `public` or `confidential`. Used by `oauth_proxy`. |
-| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Mattermost OAuth App secret. Required for confidential OAuth Apps. |
+| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Mattermost OAuth App ID for `oauth_proxy`. |
+| `MATTERMOST_OAUTH_CLIENT_TYPE` | Conditional | `confidential` | `public` or `confidential` for `oauth_proxy`. |
+| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Required for confidential OAuth Apps. |
 | `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Public base URL of this MCP server. Required for `oauth_proxy`. |
 | `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects. |
 | `MATTERMOST_OAUTH_CALLBACK_PATH` | No | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App. |
-| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | FastMCP JWT signing key. Required for public OAuth Apps, optional for confidential OAuth Apps. |
+| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | Required for public OAuth Apps; optional for confidential. |
+| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | No | true | Show the FastMCP consent screen before redirecting to Mattermost. |
+| `MATTERMOST_OAUTH_FALLBACK_ACCESS_TOKEN_EXPIRY_SECONDS` | No | — | Fallback token TTL. |
 
 ## Docker
 
@@ -229,6 +231,16 @@ Health check: `curl http://localhost:8000/health`
 
 ### HTTP mode with Mattermost OAuth proxy
 
+Register a Mattermost OAuth 2.0 Application first:
+
+| Mattermost field | Production value |
+|------------------|------------------|
+| Is Trusted | Yes |
+| Is Public Client | No |
+| Callback URLs | `https://mcp.example.com/oauth/callback/mm` |
+
+Then run the MCP server:
+
 ```bash
 docker run -d -p 8000:8000 \
   -e MCP_TRANSPORT=http \
@@ -243,14 +255,17 @@ docker run -d -p 8000:8000 \
   legard/mcp-server-mattermost
 ```
 
-Register the Mattermost OAuth App callback URL as:
-
-```text
-https://mcp.example.com/oauth/callback/mm
-```
-
 If your Mattermost login uses Keycloak SSO, users authenticate through Keycloak inside
 the Mattermost OAuth login flow. The MCP server does not need a Keycloak client.
+
+Connect Claude Code with Dynamic Client Registration:
+
+```bash
+claude mcp add --transport http mattermost https://mcp.example.com/mcp
+```
+
+Do not pass `--client-id` for this server; the MCP client registers with the MCP server,
+and the MCP server uses the fixed Mattermost OAuth App upstream.
 
 ### Environment Variables (Docker)
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,278 @@
+# Authentication
+
+The MCP server supports three authentication modes selected by the
+`MATTERMOST_AUTH_MODE` environment variable. Each mode targets a different
+deployment scenario.
+
+## Choosing a mode
+
+| Mode | Best for | Token source |
+|------|----------|--------------|
+| `static_token` (default) | Local stdio clients, bot accounts, single-user automation | Bot or personal access token in `MATTERMOST_TOKEN` |
+| `client_token` | HTTP transport where each client already has a Mattermost token | `Authorization: Bearer <token>` from the MCP client |
+| `oauth_proxy` | Remote HTTP MCP clients where each user signs in through Mattermost SSO | OAuth flow via Mattermost OAuth 2.0 Application |
+
+## `static_token`
+
+The simplest mode. The server uses one bot or personal access token for every
+Mattermost API call. All MCP tool calls act as that single identity.
+
+### When to use
+
+- Local stdio with Claude Desktop, Cursor, or Claude Code
+- Server-side automation where a single shared identity is acceptable
+- Initial trial and quickstart
+
+### Setup
+
+1. Get a Mattermost token: **System Console → Integrations → Bot Accounts**, or
+   **Profile → Security → Personal Access Tokens** for your own account.
+2. Set `MATTERMOST_URL` and `MATTERMOST_TOKEN` and run the server. See
+   [Quick Start](quickstart.md) for client-specific configuration.
+
+### Token permissions
+
+The token needs these Mattermost permissions for full functionality:
+
+- `view_team` — list teams
+- `list_team_channels` — list public channels
+- `read_channel` — read channel messages
+- `create_post` — send messages
+- `delete_post` — delete messages
+- `add_reaction` / `remove_reaction` — manage reactions
+- `manage_channels` — create channels (optional)
+
+Bot accounts get most permissions automatically. Personal access tokens inherit
+the user's permissions.
+
+## `client_token`
+
+HTTP transport mode where each MCP client sends its own Mattermost token. The
+server validates the token against `GET /api/v4/users/me` before invoking tools,
+then uses that token for downstream Mattermost API calls.
+
+### When to use
+
+- HTTP deployments with multiple users who each hold a Mattermost token
+- Programmatic integrations with rotating or per-request tokens
+- Migration step before adopting `oauth_proxy`
+
+### Setup
+
+```bash
+export MATTERMOST_URL=https://mattermost.example.com
+export MATTERMOST_AUTH_MODE=client_token
+mcp-server-mattermost
+```
+
+MCP clients send their token in the `Authorization: Bearer <mattermost-token>`
+header on every request.
+
+### Behavioral note
+
+Requests without a validated bearer token return `401`. There is no fallback to
+`MATTERMOST_TOKEN`, even if it is set. If you need a single shared identity,
+use `static_token` instead.
+
+The deprecated `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS=true` is now an alias for
+this mode. Prefer setting `MATTERMOST_AUTH_MODE=client_token` explicitly.
+
+## `oauth_proxy`
+
+Each MCP client authenticates with the MCP server through the standard MCP
+OAuth flow. FastMCP `OAuthProxy` provides the OAuth Authorization Server
+endpoints (`/register`, `/authorize`, `/token`) and proxies the browser login
+to a Mattermost OAuth 2.0 Application. Mattermost performs the actual login
+through its configured authentication provider (local accounts, SSO, Keycloak),
+and the MCP server keeps the resulting Mattermost token to forward in
+subsequent API calls on behalf of the user.
+
+### When to use
+
+- Remote HTTP MCP clients where each user must act as themselves in Mattermost
+- Production deployments with audit requirements
+- Setups where Mattermost SSO (Keycloak, Okta, etc.) is the source of truth
+
+Do not set `MATTERMOST_TOKEN` in this mode; tool calls use the token obtained
+from the authenticated user.
+
+### Architecture
+
+```text
+MCP Client (Claude Code)
+    │
+    │  1. DCR + OAuth flow with the MCP server
+    ▼
+MCP Server (FastMCP OAuthProxy)
+    │
+    │  2. Browser redirect to Mattermost /oauth/authorize
+    ▼
+Mattermost OAuth Application
+    │
+    │  3. Local login or SSO (Keycloak, ...)
+    ▼
+Browser redirected to MCP Server /oauth/callback/mm
+    │
+    │  4. MCP Server stores upstream Mattermost token
+    ▼
+MCP Client receives MCP access token, calls tools normally
+```
+
+### Step 1 — Register the Mattermost OAuth App
+
+In Mattermost, enable OAuth service provider support
+(`ServiceSettings.EnableOAuthServiceProvider=true`, see
+[Mattermost integration configuration docs](https://docs.mattermost.com/administration-guide/configure/integrations-configuration-settings.html#enable-oauth-2-0-service-provider)),
+then register the App under **System Console → Integrations →
+OAuth 2.0 Applications**.
+
+| Field | Public client mode | Confidential client mode |
+|-------|--------------------|--------------------------|
+| Is Trusted | Yes | Yes |
+| Is Public Client | Yes | No |
+| Client Secret | Not used | Required (Mattermost generates it) |
+| Callback URL | `{MCP public URL}/oauth/callback/mm` | `{MCP public URL}/oauth/callback/mm` |
+
+The callback URL must match `MATTERMOST_OAUTH_MCP_PUBLIC_URL` +
+`MATTERMOST_OAUTH_CALLBACK_PATH` exactly. Default callback path is
+`/oauth/callback/mm`.
+
+Display Name and Homepage are end-user-visible on the OAuth consent screen but
+do not affect the flow. Set them to whatever your users will recognise.
+
+Use **confidential** mode in production. Use **public** mode only when
+Mattermost is configured for public OAuth clients, typically for development.
+
+### Step 2 — Configure the MCP server
+
+Confidential client (production):
+
+```bash
+MCP_TRANSPORT=http
+MCP_HOST=0.0.0.0
+MCP_PORT=8000
+
+MATTERMOST_AUTH_MODE=oauth_proxy
+MATTERMOST_URL=https://mattermost.internal
+MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com
+MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com
+MATTERMOST_OAUTH_CLIENT_ID=<mattermost-oauth-app-id>
+MATTERMOST_OAUTH_CLIENT_TYPE=confidential
+MATTERMOST_OAUTH_CLIENT_SECRET=<mattermost-oauth-app-secret>
+```
+
+Public client (development or public-OAuth setups):
+
+```bash
+MCP_TRANSPORT=http
+MCP_HOST=0.0.0.0
+MCP_PORT=8000
+
+MATTERMOST_AUTH_MODE=oauth_proxy
+MATTERMOST_URL=https://mattermost.example.com
+MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com
+MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com
+MATTERMOST_OAUTH_CLIENT_ID=<mattermost-oauth-app-id>
+MATTERMOST_OAUTH_CLIENT_TYPE=public
+MATTERMOST_OAUTH_JWT_SIGNING_KEY=<stable-signing-key>
+```
+
+`MATTERMOST_OAUTH_JWT_SIGNING_KEY` is required for public clients (FastMCP
+needs a stable secret for signing its own JWTs because no upstream client
+secret is available). Use a long, random value and keep it stable across
+restarts.
+
+#### URL roles
+
+Three URLs serve different purposes:
+
+| Variable | Reachable from | Purpose |
+|----------|----------------|---------|
+| `MATTERMOST_URL` | MCP server process | Server-to-server API calls and the OAuth token endpoint |
+| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | User's browser | Browser redirect to `/oauth/authorize` |
+| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | User's browser | OAuth metadata, callback, and DCR endpoints |
+
+In Docker or Kubernetes, `MATTERMOST_URL` is often an internal service URL
+(`http://mattermost:8065`). `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` must be
+externally reachable; if it is left unset, it falls back to `MATTERMOST_URL`,
+which usually fails when the internal URL is not browser-reachable.
+
+### Step 3 — Connect the MCP client
+
+The MCP client does not need to be registered in Mattermost. FastMCP handles
+**Dynamic Client Registration** (DCR) locally between the MCP client and the
+MCP server. The MCP client posts its own metadata (including its callback URL)
+to the MCP server's `/register` endpoint and receives back a `client_id`.
+
+For Claude Code:
+
+```bash
+claude mcp add --transport http mattermost https://mcp.example.com/mcp
+```
+
+Do not pass `--client-id` for this server. Claude Code uses DCR with the MCP
+server, and the MCP server uses the fixed Mattermost OAuth App credentials
+upstream.
+
+If a previous connection cached tokens for a different OAuth mode, remove or
+reconnect the MCP server in the client before retrying.
+
+#### Allowed MCP client redirect URIs
+
+By default the proxy accepts only loopback redirect URIs
+(`http://localhost:*`, `http://127.0.0.1:*`). This covers Claude Code, Claude
+Desktop, and most local IDE plugins. For non-loopback MCP clients (a hosted
+web client, a remote agent, a browser-based client behind your own domain),
+set `MATTERMOST_OAUTH_ALLOWED_REDIRECT_URIS` to a JSON array of glob patterns:
+
+```bash
+MATTERMOST_OAUTH_ALLOWED_REDIRECT_URIS='["https://*.example.com/*"]'
+```
+
+Clients whose registered redirect URI does not match any pattern are rejected
+at DCR registration time.
+
+### Keycloak and SSO
+
+The MCP server does not register directly in Keycloak. Keycloak (or any other
+SSO provider) is used by Mattermost itself for user login. Configure the
+Keycloak-to-Mattermost login path in Mattermost first; then register the MCP
+OAuth App in Mattermost as described above. Mattermost issues the OAuth token
+that the MCP server uses for API calls.
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Browser shows "can't connect" after consent | `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` is unset and `MATTERMOST_URL` is internal | Set `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` to the externally reachable Mattermost URL |
+| MCP client gets `400 Bad Request` at `/register` | Client's redirect URI is not in `MATTERMOST_OAUTH_ALLOWED_REDIRECT_URIS` | Add the client's domain to the allow-list |
+| Mattermost rejects the authorize request | `MATTERMOST_OAUTH_MCP_PUBLIC_URL` + `MATTERMOST_OAUTH_CALLBACK_PATH` differs from the App's Callback URL | Make them match exactly, including trailing path |
+| Settings refuses to load: "must use HTTPS unless localhost" | `MATTERMOST_OAUTH_MCP_PUBLIC_URL` is plain HTTP and not localhost | Use HTTPS in production, or test with `http://localhost:<port>` |
+| Old MCP client cached the wrong tokens | Previous connection used a different auth mode | Remove and re-add the server in the MCP client |
+
+## Configuration reference
+
+All authentication-related environment variables. For non-auth settings
+(timeouts, logging, SSL), see [Configuration](configuration.md).
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MATTERMOST_AUTH_MODE` | No | `static_token` | `static_token`, `client_token`, or `oauth_proxy` |
+| `MATTERMOST_TOKEN` | Conditional | — | Required for `static_token`. Bot or personal access token |
+| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token`. Conflicts with an explicit `MATTERMOST_AUTH_MODE` set to anything else |
+| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Required for `oauth_proxy`. Mattermost OAuth App ID |
+| `MATTERMOST_OAUTH_CLIENT_TYPE` | No | `confidential` | `public` or `confidential` |
+| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Required for confidential OAuth Apps |
+| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | Required for public OAuth Apps; optional for confidential |
+| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Required for `oauth_proxy`. Public base URL of this MCP server. Must be HTTPS unless localhost |
+| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects |
+| `MATTERMOST_OAUTH_CALLBACK_PATH` | No | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App |
+| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | No | true | Show the FastMCP consent screen before redirecting to Mattermost |
+| `MATTERMOST_OAUTH_ALLOWED_REDIRECT_URIS` | No | `["http://localhost:*", "http://127.0.0.1:*"]` | JSON array of glob patterns for MCP client redirect URIs accepted via DCR |
+| `MATTERMOST_OAUTH_FALLBACK_ACCESS_TOKEN_EXPIRY_SECONDS` | No | — | Fallback access token TTL in seconds (≥1). Used only when Mattermost omits `expires_in` in the token response |
+
+!!! warning "Security considerations"
+    In `client_token` and `oauth_proxy` modes, any user who can reach the MCP
+    server's HTTP endpoint and has a valid Mattermost account can execute MCP
+    tools under their own identity. Protect the MCP server with network-level
+    access controls such as a firewall, VPN, or trusted reverse proxy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,20 +2,14 @@
 
 All configuration is done via environment variables with the `MATTERMOST_` prefix.
 
+For authentication-related variables (`MATTERMOST_AUTH_MODE`, `MATTERMOST_TOKEN`,
+all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
+
 ## Required Variables
 
 | Variable | Description |
 |----------|-------------|
 | `MATTERMOST_URL` | Mattermost server URL (e.g., `https://mattermost.example.com`) |
-
-## Conditional Variables
-
-| Variable | Description |
-|----------|-------------|
-| `MATTERMOST_TOKEN` | Bot or personal access token. Required only when `MATTERMOST_AUTH_MODE=static_token`. |
-| `MATTERMOST_OAUTH_CLIENT_ID` | Mattermost OAuth App client ID. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
-| `MATTERMOST_OAUTH_CLIENT_SECRET` | Mattermost OAuth App secret. Required for confidential OAuth Apps. |
-| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Public base URL of this MCP server. Required for `oauth_proxy`. |
 
 ## Optional Variables
 
@@ -27,14 +21,6 @@ All configuration is done via environment variables with the `MATTERMOST_` prefi
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |
-| `MATTERMOST_AUTH_MODE` | static_token | Authentication mode: `static_token`, `client_token`, or `oauth_proxy` |
-| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
-| `MATTERMOST_OAUTH_CLIENT_TYPE` | confidential | Mattermost OAuth App type: `public` or `confidential` |
-| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects |
-| `MATTERMOST_OAUTH_CALLBACK_PATH` | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App |
-| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | — | Required for public OAuth Apps; optional for confidential OAuth Apps |
-| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | true | Show the FastMCP consent screen before redirecting to Mattermost |
-| `MATTERMOST_OAUTH_FALLBACK_ACCESS_TOKEN_EXPIRY_SECONDS` | — | Fallback token TTL |
 
 ## Environment File
 
@@ -46,149 +32,3 @@ MATTERMOST_TOKEN=your-token-here
 MATTERMOST_TIMEOUT=60
 MATTERMOST_LOG_LEVEL=DEBUG
 ```
-
-## Authentication Modes
-
-`MATTERMOST_AUTH_MODE` selects one authentication strategy per server process.
-
-### `static_token`
-
-Default mode. The server uses `MATTERMOST_TOKEN` for every Mattermost API request.
-Use this for stdio, bot accounts, and single-user deployments.
-
-### `client_token`
-
-HTTP clients send their own Mattermost token in `Authorization: Bearer <token>`.
-The server validates it through `GET /api/v4/users/me` and then uses that token for
-Mattermost API calls.
-
-`MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS=true` is a deprecated alias for this mode.
-
-### `oauth_proxy`
-
-Remote MCP clients authenticate with the MCP server through the standard MCP OAuth flow.
-FastMCP `OAuthProxy` provides the OAuth Authorization Server endpoints for MCP clients
-(`/register`, `/authorize`, `/token`) and proxies the browser login to Mattermost OAuth.
-Mattermost performs login through its configured authentication provider, for example
-Keycloak SSO, and the MCP server stores the resulting Mattermost user token as an
-upstream token.
-
-Use this mode when each MCP client must act as the Mattermost user who approved the
-OAuth flow. Do not set `MATTERMOST_TOKEN` in this mode; tool calls use the token obtained
-from the authenticated user.
-
-#### Mattermost OAuth App
-
-Mattermost must have OAuth service provider support enabled. In the Mattermost System
-Console, check the integration setting named **Enable OAuth 2.0 Service Provider**. On
-self-hosted Mattermost this maps to `ServiceSettings.EnableOAuthServiceProvider=true`.
-See the Mattermost integration configuration docs for the upstream setting:
-<https://docs.mattermost.com/administration-guide/configure/integrations-configuration-settings.html#enable-oauth-2-0-service-provider>.
-
-Create the OAuth app in Mattermost under **Integrations** -> **OAuth 2.0 Applications**.
-The callback URL is fixed from Mattermost's point of view:
-
-```text
-{MATTERMOST_OAUTH_MCP_PUBLIC_URL}{MATTERMOST_OAUTH_CALLBACK_PATH}
-```
-
-For example:
-
-```text
-https://mcp.example.com/oauth/callback/mm
-```
-
-Mattermost OAuth App settings:
-
-| Setting | Public client mode | Confidential client mode |
-|---------|--------------------|--------------------------|
-| Is Trusted | Yes | Yes |
-| Is Public Client | Yes | No |
-| Client Secret | Empty | Required |
-| Callback URL | `{MCP public URL}/oauth/callback/mm` | `{MCP public URL}/oauth/callback/mm` |
-| PKCE | S256 | S256 |
-
-Use confidential mode for production when Mattermost provides a client secret. Use public
-mode only for development or environments where the Mattermost OAuth App is explicitly
-created as a public client; public mode requires a stable `MATTERMOST_OAUTH_JWT_SIGNING_KEY`.
-
-#### MCP Server Environment
-
-Confidential production example:
-
-```bash
-MCP_TRANSPORT=http
-MCP_HOST=0.0.0.0
-MCP_PORT=8000
-
-MATTERMOST_AUTH_MODE=oauth_proxy
-MATTERMOST_URL=https://mattermost.internal
-MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com
-MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com
-MATTERMOST_OAUTH_CLIENT_ID=<mattermost-oauth-app-id>
-MATTERMOST_OAUTH_CLIENT_TYPE=confidential
-MATTERMOST_OAUTH_CLIENT_SECRET=<mattermost-oauth-app-secret>
-```
-
-Public-client example:
-
-```bash
-MCP_TRANSPORT=http
-MCP_HOST=0.0.0.0
-MCP_PORT=8000
-
-MATTERMOST_AUTH_MODE=oauth_proxy
-MATTERMOST_URL=https://mattermost.example.com
-MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com
-MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com
-MATTERMOST_OAUTH_CLIENT_ID=<mattermost-oauth-app-id>
-MATTERMOST_OAUTH_CLIENT_TYPE=public
-MATTERMOST_OAUTH_JWT_SIGNING_KEY=<stable-signing-key>
-```
-
-`MATTERMOST_URL` is the URL reachable by the MCP server process. In Docker this is often
-an internal service URL such as `http://mattermost:8065`. `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL`
-is the URL opened in the user's browser during OAuth login.
-
-#### MCP Client Registration
-
-The MCP client does not need to be registered in Mattermost. FastMCP handles Dynamic Client
-Registration locally between the MCP client and this server. For Claude Code, do not pass a
-fixed `--client-id` for this server; let Claude Code register dynamically so its loopback
-callback, such as `http://localhost:<port>/callback`, is accepted by the MCP server.
-
-Connect Claude Code to a remote HTTP server with:
-
-```bash
-claude mcp add --transport http mattermost https://mcp.example.com/mcp
-```
-
-If a previous connection attempted a different OAuth mode and cached tokens, remove or
-reconnect the MCP server in the client before retrying.
-
-#### Keycloak and SSO
-
-The MCP server does not register directly in Keycloak. Keycloak is used by Mattermost for
-SSO login, and Mattermost issues the OAuth token that the MCP server uses for API calls.
-Configure the Keycloak-to-Mattermost login path in Mattermost first; then register the MCP
-OAuth App in Mattermost as described above.
-
-!!! warning "Security Considerations"
-    In `client_token` and `oauth_proxy` modes, any user who can reach the MCP server's
-    HTTP endpoint and has a valid Mattermost account can execute MCP tools under their
-    own identity. Protect the MCP server with network-level access controls such as a
-    firewall, VPN, or trusted reverse proxy.
-
-## Token Permissions
-
-The bot token needs these permissions for full functionality:
-
-| Permission | Required For |
-|------------|--------------|
-| `create_post` | Sending messages |
-| `read_channel` | Reading channel messages |
-| `manage_channel_members` | Adding users to channels |
-| `create_direct_channel` | Creating DM channels |
-| `upload_files` | File uploads |
-
-For read-only usage, only `read_channel` permission is needed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,10 @@ All configuration is done via environment variables with the `MATTERMOST_` prefi
 
 | Variable | Description |
 |----------|-------------|
-| `MATTERMOST_TOKEN` | Bot or personal access token. MATTERMOST_TOKEN is required only when per-client token authentication (MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS) is not enabled. |
+| `MATTERMOST_TOKEN` | Bot or personal access token. Required only when `MATTERMOST_AUTH_MODE=static_token`. |
+| `MATTERMOST_OAUTH_CLIENT_ID` | Mattermost OAuth App client ID. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
+| `MATTERMOST_OAUTH_CLIENT_SECRET` | Mattermost OAuth App secret. Required for confidential OAuth Apps. |
+| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Public base URL of this MCP server. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
 
 ## Optional Variables
 
@@ -24,7 +27,12 @@ All configuration is done via environment variables with the `MATTERMOST_` prefi
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |
-| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | false | Allow HTTP clients to authenticate with their own Mattermost tokens |
+| `MATTERMOST_AUTH_MODE` | static_token | Authentication mode: `static_token`, `client_token`, or `oauth_proxy` |
+| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
+| `MATTERMOST_OAUTH_CLIENT_TYPE` | confidential | Mattermost OAuth App type: `public` or `confidential` |
+| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects |
+| `MATTERMOST_OAUTH_CALLBACK_PATH` | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App |
+| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | — | FastMCP JWT signing key. Required for public OAuth Apps, optional for confidential OAuth Apps. |
 
 ## Environment File
 
@@ -37,28 +45,49 @@ MATTERMOST_TIMEOUT=60
 MATTERMOST_LOG_LEVEL=DEBUG
 ```
 
-## Per-Client Token Authentication
+## Authentication Modes
 
-By default, the server uses the `MATTERMOST_TOKEN` environment variable for all API requests. When `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` is set to `true`, HTTP clients (e.g., over SSE transport) can pass their own Mattermost token via the `Authorization: Bearer <token>` header.
+`MATTERMOST_AUTH_MODE` selects one authentication strategy per server process.
 
-**How it works:**
+### `static_token`
 
-1. The client sends a bearer token in the `Authorization` header
-2. The server validates the token by calling `GET /api/v4/users/me` on the Mattermost server
-3. If valid, the client's token is used for all subsequent API requests in that session
-4. If invalid, the server responds with `401 Unauthorized`
+Default mode. The server uses `MATTERMOST_TOKEN` for every Mattermost API request.
+Use this for stdio, bot accounts, and single-user deployments.
 
-This is useful in multi-user environments where each user should act under their own Mattermost identity rather than a shared bot account.
+### `client_token`
 
-!!! note
-    This feature only applies to HTTP-based transports (SSE, StreamableHTTP). When using stdio transport (e.g., Claude Desktop), the server always uses `MATTERMOST_TOKEN`.
+HTTP clients send their own Mattermost token in `Authorization: Bearer <token>`.
+The server validates it through `GET /api/v4/users/me` and then uses that token for
+Mattermost API calls.
+
+`MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS=true` is a deprecated alias for this mode.
+
+### `oauth_proxy`
+
+Remote MCP clients authenticate with the MCP server through the standard MCP OAuth
+flow. FastMCP `OAuthProxy` redirects the user to Mattermost OAuth, Mattermost performs
+login through its configured SSO provider such as Keycloak, and the MCP server stores
+the resulting Mattermost user token as an upstream token.
+
+Mattermost OAuth App settings:
+
+| Setting | Public PoC mode | Confidential production mode |
+|---------|-----------------|------------------------------|
+| Is Trusted | Yes | Yes |
+| Is Public Client | Yes | No |
+| Client Secret | Empty | Required |
+| Callback URL | `{MATTERMOST_OAUTH_MCP_PUBLIC_URL}/oauth/callback/mm` | `{MATTERMOST_OAUTH_MCP_PUBLIC_URL}/oauth/callback/mm` |
+| PKCE | S256 | S256 |
+
+The MCP server does not register directly in Keycloak. Keycloak is used by Mattermost
+for SSO login, and Mattermost issues the OAuth token that the MCP server uses for API
+calls.
 
 !!! warning "Security Considerations"
-    When enabled, the MCP server forwards any valid Mattermost token to the API.
-    This means any user who can reach the MCP server's HTTP endpoint and has a
-    valid Mattermost account can execute MCP tools under their own identity.
-    Ensure the MCP server is protected by network-level access controls
-    (firewall, VPN, reverse proxy with authentication) in production deployments.
+    In `client_token` and `oauth_proxy` modes, any user who can reach the MCP server's
+    HTTP endpoint and has a valid Mattermost account can execute MCP tools under their
+    own identity. Protect the MCP server with network-level access controls such as a
+    firewall, VPN, or trusted reverse proxy.
 
 ## Token Permissions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ All configuration is done via environment variables with the `MATTERMOST_` prefi
 | `MATTERMOST_TOKEN` | Bot or personal access token. Required only when `MATTERMOST_AUTH_MODE=static_token`. |
 | `MATTERMOST_OAUTH_CLIENT_ID` | Mattermost OAuth App client ID. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
 | `MATTERMOST_OAUTH_CLIENT_SECRET` | Mattermost OAuth App secret. Required for confidential OAuth Apps. |
-| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Public base URL of this MCP server. Required when `MATTERMOST_AUTH_MODE=oauth_proxy`. |
+| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Public base URL of this MCP server. Required for `oauth_proxy`. |
 
 ## Optional Variables
 
@@ -32,7 +32,9 @@ All configuration is done via environment variables with the `MATTERMOST_` prefi
 | `MATTERMOST_OAUTH_CLIENT_TYPE` | confidential | Mattermost OAuth App type: `public` or `confidential` |
 | `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | `MATTERMOST_URL` | Browser-facing Mattermost URL for OAuth redirects |
 | `MATTERMOST_OAUTH_CALLBACK_PATH` | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App |
-| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | — | FastMCP JWT signing key. Required for public OAuth Apps, optional for confidential OAuth Apps. |
+| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | — | Required for public OAuth Apps; optional for confidential OAuth Apps |
+| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | true | Show the FastMCP consent screen before redirecting to Mattermost |
+| `MATTERMOST_OAUTH_FALLBACK_ACCESS_TOKEN_EXPIRY_SECONDS` | — | Fallback token TTL |
 
 ## Environment File
 
@@ -64,24 +66,112 @@ Mattermost API calls.
 
 ### `oauth_proxy`
 
-Remote MCP clients authenticate with the MCP server through the standard MCP OAuth
-flow. FastMCP `OAuthProxy` redirects the user to Mattermost OAuth, Mattermost performs
-login through its configured SSO provider such as Keycloak, and the MCP server stores
-the resulting Mattermost user token as an upstream token.
+Remote MCP clients authenticate with the MCP server through the standard MCP OAuth flow.
+FastMCP `OAuthProxy` provides the OAuth Authorization Server endpoints for MCP clients
+(`/register`, `/authorize`, `/token`) and proxies the browser login to Mattermost OAuth.
+Mattermost performs login through its configured authentication provider, for example
+Keycloak SSO, and the MCP server stores the resulting Mattermost user token as an
+upstream token.
+
+Use this mode when each MCP client must act as the Mattermost user who approved the
+OAuth flow. Do not set `MATTERMOST_TOKEN` in this mode; tool calls use the token obtained
+from the authenticated user.
+
+#### Mattermost OAuth App
+
+Mattermost must have OAuth service provider support enabled. In the Mattermost System
+Console, check the integration setting named **Enable OAuth 2.0 Service Provider**. On
+self-hosted Mattermost this maps to `ServiceSettings.EnableOAuthServiceProvider=true`.
+See the Mattermost integration configuration docs for the upstream setting:
+<https://docs.mattermost.com/administration-guide/configure/integrations-configuration-settings.html#enable-oauth-2-0-service-provider>.
+
+Create the OAuth app in Mattermost under **Integrations** -> **OAuth 2.0 Applications**.
+The callback URL is fixed from Mattermost's point of view:
+
+```text
+{MATTERMOST_OAUTH_MCP_PUBLIC_URL}{MATTERMOST_OAUTH_CALLBACK_PATH}
+```
+
+For example:
+
+```text
+https://mcp.example.com/oauth/callback/mm
+```
 
 Mattermost OAuth App settings:
 
-| Setting | Public PoC mode | Confidential production mode |
-|---------|-----------------|------------------------------|
+| Setting | Public client mode | Confidential client mode |
+|---------|--------------------|--------------------------|
 | Is Trusted | Yes | Yes |
 | Is Public Client | Yes | No |
 | Client Secret | Empty | Required |
-| Callback URL | `{MATTERMOST_OAUTH_MCP_PUBLIC_URL}/oauth/callback/mm` | `{MATTERMOST_OAUTH_MCP_PUBLIC_URL}/oauth/callback/mm` |
+| Callback URL | `{MCP public URL}/oauth/callback/mm` | `{MCP public URL}/oauth/callback/mm` |
 | PKCE | S256 | S256 |
 
-The MCP server does not register directly in Keycloak. Keycloak is used by Mattermost
-for SSO login, and Mattermost issues the OAuth token that the MCP server uses for API
-calls.
+Use confidential mode for production when Mattermost provides a client secret. Use public
+mode only for development or environments where the Mattermost OAuth App is explicitly
+created as a public client; public mode requires a stable `MATTERMOST_OAUTH_JWT_SIGNING_KEY`.
+
+#### MCP Server Environment
+
+Confidential production example:
+
+```bash
+MCP_TRANSPORT=http
+MCP_HOST=0.0.0.0
+MCP_PORT=8000
+
+MATTERMOST_AUTH_MODE=oauth_proxy
+MATTERMOST_URL=https://mattermost.internal
+MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com
+MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com
+MATTERMOST_OAUTH_CLIENT_ID=<mattermost-oauth-app-id>
+MATTERMOST_OAUTH_CLIENT_TYPE=confidential
+MATTERMOST_OAUTH_CLIENT_SECRET=<mattermost-oauth-app-secret>
+```
+
+Public-client example:
+
+```bash
+MCP_TRANSPORT=http
+MCP_HOST=0.0.0.0
+MCP_PORT=8000
+
+MATTERMOST_AUTH_MODE=oauth_proxy
+MATTERMOST_URL=https://mattermost.example.com
+MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com
+MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com
+MATTERMOST_OAUTH_CLIENT_ID=<mattermost-oauth-app-id>
+MATTERMOST_OAUTH_CLIENT_TYPE=public
+MATTERMOST_OAUTH_JWT_SIGNING_KEY=<stable-signing-key>
+```
+
+`MATTERMOST_URL` is the URL reachable by the MCP server process. In Docker this is often
+an internal service URL such as `http://mattermost:8065`. `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL`
+is the URL opened in the user's browser during OAuth login.
+
+#### MCP Client Registration
+
+The MCP client does not need to be registered in Mattermost. FastMCP handles Dynamic Client
+Registration locally between the MCP client and this server. For Claude Code, do not pass a
+fixed `--client-id` for this server; let Claude Code register dynamically so its loopback
+callback, such as `http://localhost:<port>/callback`, is accepted by the MCP server.
+
+Connect Claude Code to a remote HTTP server with:
+
+```bash
+claude mcp add --transport http mattermost https://mcp.example.com/mcp
+```
+
+If a previous connection attempted a different OAuth mode and cached tokens, remove or
+reconnect the MCP server in the client before retrying.
+
+#### Keycloak and SSO
+
+The MCP server does not register directly in Keycloak. Keycloak is used by Mattermost for
+SSO login, and Mattermost issues the OAuth token that the MCP server uses for API calls.
+Configure the Keycloak-to-Mattermost login path in Mattermost first; then register the MCP
+OAuth App in Mattermost as described above.
 
 !!! warning "Security Considerations"
     In `client_token` and `oauth_proxy` modes, any user who can reach the MCP server's

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -58,35 +58,13 @@ curl http://localhost:8000/health
 
 ## HTTP Mode with Mattermost OAuth Proxy
 
-Use `oauth_proxy` when HTTP MCP clients should sign in with their own Mattermost
-identity. The MCP server acts as the OAuth server for MCP clients and proxies the
-browser login to a Mattermost OAuth 2.0 Application.
-
-### Mattermost App
-
-Create a Mattermost OAuth 2.0 Application with this callback:
-
-```text
-https://mcp.example.com/oauth/callback/mm
-```
-
-Production settings:
-
-| Mattermost OAuth App field | Value |
-|----------------------------|-------|
-| Is Trusted | Yes |
-| Is Public Client | No |
-| Callback URLs | `https://mcp.example.com/oauth/callback/mm` |
-
-Keep the generated client ID and client secret.
-
-### Docker Run
+For production deployments where each user signs in with their own Mattermost
+identity, run with `MATTERMOST_AUTH_MODE=oauth_proxy`:
 
 ```bash
-docker run -d --name mattermost-mcp -p 8000:8000 \
+docker run -d -p 8000:8000 \
   -e MCP_TRANSPORT=http \
   -e MCP_HOST=0.0.0.0 \
-  -e MCP_PORT=8000 \
   -e MATTERMOST_AUTH_MODE=oauth_proxy \
   -e MATTERMOST_URL=https://mattermost.internal \
   -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
@@ -97,52 +75,19 @@ docker run -d --name mattermost-mcp -p 8000:8000 \
   legard/mcp-server-mattermost
 ```
 
-For public-client mode, omit the client secret and provide a stable JWT signing key:
-
-```bash
-docker run -d --name mattermost-mcp -p 8000:8000 \
-  -e MCP_TRANSPORT=http \
-  -e MCP_HOST=0.0.0.0 \
-  -e MCP_PORT=8000 \
-  -e MATTERMOST_AUTH_MODE=oauth_proxy \
-  -e MATTERMOST_URL=https://mattermost.example.com \
-  -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
-  -e MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com \
-  -e MATTERMOST_OAUTH_CLIENT_ID=your-mattermost-oauth-app-id \
-  -e MATTERMOST_OAUTH_CLIENT_TYPE=public \
-  -e MATTERMOST_OAUTH_JWT_SIGNING_KEY=change-me-to-a-stable-key \
-  legard/mcp-server-mattermost
-```
-
-### Client Connection
-
-Claude Code:
-
-```bash
-claude mcp add --transport http mattermost https://mcp.example.com/mcp
-```
-
-Do not pass a fixed `--client-id` for this server. FastMCP Dynamic Client Registration
-accepts the MCP client's loopback callback and maps it to the fixed Mattermost callback.
+See [Authentication / oauth_proxy](authentication.md#oauth_proxy) for Mattermost
+OAuth App registration, the public-client variant, and MCP client connection.
 
 ## Environment Variables
+
+For authentication-related variables (`MATTERMOST_AUTH_MODE`, `MATTERMOST_TOKEN`,
+all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md#configuration-reference).
 
 ### Mattermost Settings
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MATTERMOST_URL` | Yes | — | Mattermost server URL |
-| `MATTERMOST_AUTH_MODE` | No | `static_token` | Authentication mode: `static_token`, `client_token`, or `oauth_proxy` |
-| `MATTERMOST_TOKEN` | Conditional | — | Required for `static_token` mode |
-| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
-| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Mattermost OAuth App client ID for `oauth_proxy` |
-| `MATTERMOST_OAUTH_CLIENT_TYPE` | Conditional | `confidential` | `public` or `confidential` OAuth App |
-| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Required for confidential OAuth Apps |
-| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Public base URL of this MCP server |
-| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL |
-| `MATTERMOST_OAUTH_CALLBACK_PATH` | No | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App |
-| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | Required for public OAuth Apps |
-| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | No | true | Show the FastMCP consent screen before redirecting to Mattermost |
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -63,7 +63,14 @@ curl http://localhost:8000/health
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MATTERMOST_URL` | Yes | — | Mattermost server URL |
-| `MATTERMOST_TOKEN` | Yes | — | Bot or personal access token |
+| `MATTERMOST_AUTH_MODE` | No | `static_token` | Authentication mode: `static_token`, `client_token`, or `oauth_proxy` |
+| `MATTERMOST_TOKEN` | Conditional | — | Required for `static_token` mode |
+| `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` | No | false | Deprecated alias for `MATTERMOST_AUTH_MODE=client_token` |
+| `MATTERMOST_OAUTH_CLIENT_ID` | Conditional | — | Mattermost OAuth App client ID for `oauth_proxy` |
+| `MATTERMOST_OAUTH_CLIENT_TYPE` | Conditional | `confidential` | `public` or `confidential` OAuth App |
+| `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Required for confidential OAuth Apps |
+| `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Public base URL of this MCP server |
+| `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL |
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -56,6 +56,75 @@ Health check endpoint:
 curl http://localhost:8000/health
 ```
 
+## HTTP Mode with Mattermost OAuth Proxy
+
+Use `oauth_proxy` when HTTP MCP clients should sign in with their own Mattermost
+identity. The MCP server acts as the OAuth server for MCP clients and proxies the
+browser login to a Mattermost OAuth 2.0 Application.
+
+### Mattermost App
+
+Create a Mattermost OAuth 2.0 Application with this callback:
+
+```text
+https://mcp.example.com/oauth/callback/mm
+```
+
+Production settings:
+
+| Mattermost OAuth App field | Value |
+|----------------------------|-------|
+| Is Trusted | Yes |
+| Is Public Client | No |
+| Callback URLs | `https://mcp.example.com/oauth/callback/mm` |
+
+Keep the generated client ID and client secret.
+
+### Docker Run
+
+```bash
+docker run -d --name mattermost-mcp -p 8000:8000 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HOST=0.0.0.0 \
+  -e MCP_PORT=8000 \
+  -e MATTERMOST_AUTH_MODE=oauth_proxy \
+  -e MATTERMOST_URL=https://mattermost.internal \
+  -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
+  -e MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com \
+  -e MATTERMOST_OAUTH_CLIENT_ID=your-mattermost-oauth-app-id \
+  -e MATTERMOST_OAUTH_CLIENT_TYPE=confidential \
+  -e MATTERMOST_OAUTH_CLIENT_SECRET=your-mattermost-oauth-app-secret \
+  legard/mcp-server-mattermost
+```
+
+For public-client mode, omit the client secret and provide a stable JWT signing key:
+
+```bash
+docker run -d --name mattermost-mcp -p 8000:8000 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HOST=0.0.0.0 \
+  -e MCP_PORT=8000 \
+  -e MATTERMOST_AUTH_MODE=oauth_proxy \
+  -e MATTERMOST_URL=https://mattermost.example.com \
+  -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
+  -e MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com \
+  -e MATTERMOST_OAUTH_CLIENT_ID=your-mattermost-oauth-app-id \
+  -e MATTERMOST_OAUTH_CLIENT_TYPE=public \
+  -e MATTERMOST_OAUTH_JWT_SIGNING_KEY=change-me-to-a-stable-key \
+  legard/mcp-server-mattermost
+```
+
+### Client Connection
+
+Claude Code:
+
+```bash
+claude mcp add --transport http mattermost https://mcp.example.com/mcp
+```
+
+Do not pass a fixed `--client-id` for this server. FastMCP Dynamic Client Registration
+accepts the MCP client's loopback callback and maps it to the fixed Mattermost callback.
+
 ## Environment Variables
 
 ### Mattermost Settings
@@ -71,6 +140,9 @@ curl http://localhost:8000/health
 | `MATTERMOST_OAUTH_CLIENT_SECRET` | Conditional | — | Required for confidential OAuth Apps |
 | `MATTERMOST_OAUTH_MCP_PUBLIC_URL` | Conditional | — | Public base URL of this MCP server |
 | `MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` | No | `MATTERMOST_URL` | Browser-facing Mattermost URL |
+| `MATTERMOST_OAUTH_CALLBACK_PATH` | No | `/oauth/callback/mm` | Callback path registered in the Mattermost OAuth App |
+| `MATTERMOST_OAUTH_JWT_SIGNING_KEY` | Conditional | — | Required for public OAuth Apps |
+| `MATTERMOST_OAUTH_REQUIRE_CONSENT` | No | true | Show the FastMCP consent screen before redirecting to Mattermost |
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,8 +5,10 @@ Get up and running in 2 minutes.
 ## Prerequisites
 
 - Mattermost server with API access
-- Bot account or personal access token for local stdio mode
-- Mattermost OAuth 2.0 Application for HTTP `oauth_proxy` mode
+- Bot account or personal access token
+
+For HTTP deployments where each user signs in with their own Mattermost identity,
+see [Authentication](authentication.md) for `client_token` and `oauth_proxy` modes.
 
 ## Install
 
@@ -37,18 +39,6 @@ Get up and running in 2 minutes.
     cd mcp-server-mattermost
     uv sync
     ```
-
-## Choose an Authentication Mode
-
-| Mode | Best for | Mattermost setup |
-|------|----------|------------------|
-| `static_token` | Local stdio clients, bot accounts, simple single-user setup | Bot token or personal access token |
-| `client_token` | HTTP clients with Mattermost user tokens | Client sends `Authorization: Bearer <token>` |
-| `oauth_proxy` | Remote HTTP MCP clients where every user signs in with SSO | Mattermost OAuth 2.0 Application |
-
-The rest of this page shows `static_token` first because it is the fastest local setup.
-Use [Mattermost OAuth Proxy](#mattermost-oauth-proxy) for Claude Code or other remote
-HTTP clients that should authenticate users through Mattermost SSO.
 
 ## Get a Mattermost Token
 
@@ -136,71 +126,9 @@ HTTP clients that should authenticate users through Mattermost SSO.
 
 The Mattermost tools are now available in your conversations.
 
-## Mattermost OAuth Proxy
-
-Use this mode when the MCP server runs as an HTTP service and each user should access
-Mattermost with their own SSO-backed identity.
-
-### 1. Register the OAuth App in Mattermost
-
-In Mattermost, enable OAuth service provider support, then create an app under
-**Integrations** -> **OAuth 2.0 Applications**.
-
-Recommended production settings:
-
-| Field | Value |
-|-------|-------|
-| Is Trusted | Yes |
-| Is Public Client | No |
-| Display Name | Mattermost MCP |
-| Homepage | `https://mcp.example.com` |
-| Callback URLs | `https://mcp.example.com/oauth/callback/mm` |
-
-Save the generated client ID and client secret.
-
-For development public-client setups, set **Is Public Client** to **Yes**, leave the
-client secret empty, and register the callback URL for the MCP server URL you run.
-
-### 2. Run the MCP Server
-
-Confidential production example:
-
-    docker run -d --name mattermost-mcp -p 8000:8000 \
-      -e MCP_TRANSPORT=http \
-      -e MCP_HOST=0.0.0.0 \
-      -e MCP_PORT=8000 \
-      -e MATTERMOST_AUTH_MODE=oauth_proxy \
-      -e MATTERMOST_URL=https://mattermost.internal \
-      -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
-      -e MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com \
-      -e MATTERMOST_OAUTH_CLIENT_ID=your-mattermost-oauth-app-id \
-      -e MATTERMOST_OAUTH_CLIENT_TYPE=confidential \
-      -e MATTERMOST_OAUTH_CLIENT_SECRET=your-mattermost-oauth-app-secret \
-      legard/mcp-server-mattermost
-
-`MATTERMOST_URL` must be reachable from the MCP server.
-`MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` must be reachable from the user's browser.
-
-### 3. Connect Claude Code
-
-    claude mcp add --transport http mattermost https://mcp.example.com/mcp
-
-Do not pass `--client-id` for this server. Claude Code uses Dynamic Client Registration
-with the MCP server, and the MCP server uses the fixed Mattermost OAuth App credentials
-upstream.
-
-### 4. Complete Login
-
-On first use, Claude Code opens the browser. The flow is:
-
-1. Claude Code registers itself with the MCP server.
-2. The MCP server redirects the browser to Mattermost OAuth.
-3. Mattermost performs local login or SSO through Keycloak.
-4. Mattermost returns to `/oauth/callback/mm` on the MCP server.
-5. Claude Code receives its MCP access token and can call tools.
-
 ## Next Steps
 
+- [Authentication](authentication.md) — auth modes, OAuth proxy setup, Mattermost OAuth App registration
 - [Configuration](configuration.md) — timeouts, retries, SSL options
 - [Docker](docker.md) — container deployment and HTTP mode
 - [Tools Reference](tools/index.md) — all 36 available tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,8 @@ Get up and running in 2 minutes.
 ## Prerequisites
 
 - Mattermost server with API access
-- Bot account or personal access token
+- Bot account or personal access token for local stdio mode
+- Mattermost OAuth 2.0 Application for HTTP `oauth_proxy` mode
 
 ## Install
 
@@ -36,6 +37,18 @@ Get up and running in 2 minutes.
     cd mcp-server-mattermost
     uv sync
     ```
+
+## Choose an Authentication Mode
+
+| Mode | Best for | Mattermost setup |
+|------|----------|------------------|
+| `static_token` | Local stdio clients, bot accounts, simple single-user setup | Bot token or personal access token |
+| `client_token` | HTTP clients with Mattermost user tokens | Client sends `Authorization: Bearer <token>` |
+| `oauth_proxy` | Remote HTTP MCP clients where every user signs in with SSO | Mattermost OAuth 2.0 Application |
+
+The rest of this page shows `static_token` first because it is the fastest local setup.
+Use [Mattermost OAuth Proxy](#mattermost-oauth-proxy) for Claude Code or other remote
+HTTP clients that should authenticate users through Mattermost SSO.
 
 ## Get a Mattermost Token
 
@@ -122,6 +135,69 @@ Get up and running in 2 minutes.
 2. Test with a simple query: "List my teams" or "What channels are available?"
 
 The Mattermost tools are now available in your conversations.
+
+## Mattermost OAuth Proxy
+
+Use this mode when the MCP server runs as an HTTP service and each user should access
+Mattermost with their own SSO-backed identity.
+
+### 1. Register the OAuth App in Mattermost
+
+In Mattermost, enable OAuth service provider support, then create an app under
+**Integrations** -> **OAuth 2.0 Applications**.
+
+Recommended production settings:
+
+| Field | Value |
+|-------|-------|
+| Is Trusted | Yes |
+| Is Public Client | No |
+| Display Name | Mattermost MCP |
+| Homepage | `https://mcp.example.com` |
+| Callback URLs | `https://mcp.example.com/oauth/callback/mm` |
+
+Save the generated client ID and client secret.
+
+For development public-client setups, set **Is Public Client** to **Yes**, leave the
+client secret empty, and register the callback URL for the MCP server URL you run.
+
+### 2. Run the MCP Server
+
+Confidential production example:
+
+    docker run -d --name mattermost-mcp -p 8000:8000 \
+      -e MCP_TRANSPORT=http \
+      -e MCP_HOST=0.0.0.0 \
+      -e MCP_PORT=8000 \
+      -e MATTERMOST_AUTH_MODE=oauth_proxy \
+      -e MATTERMOST_URL=https://mattermost.internal \
+      -e MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL=https://mattermost.example.com \
+      -e MATTERMOST_OAUTH_MCP_PUBLIC_URL=https://mcp.example.com \
+      -e MATTERMOST_OAUTH_CLIENT_ID=your-mattermost-oauth-app-id \
+      -e MATTERMOST_OAUTH_CLIENT_TYPE=confidential \
+      -e MATTERMOST_OAUTH_CLIENT_SECRET=your-mattermost-oauth-app-secret \
+      legard/mcp-server-mattermost
+
+`MATTERMOST_URL` must be reachable from the MCP server.
+`MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL` must be reachable from the user's browser.
+
+### 3. Connect Claude Code
+
+    claude mcp add --transport http mattermost https://mcp.example.com/mcp
+
+Do not pass `--client-id` for this server. Claude Code uses Dynamic Client Registration
+with the MCP server, and the MCP server uses the fixed Mattermost OAuth App credentials
+upstream.
+
+### 4. Complete Login
+
+On first use, Claude Code opens the browser. The flow is:
+
+1. Claude Code registers itself with the MCP server.
+2. The MCP server redirects the browser to Mattermost OAuth.
+3. Mattermost performs local login or SSO through Keycloak.
+4. Mattermost returns to `/oauth/callback/mm` on the MCP server.
+5. Claude Code receives its MCP access token and can call tools.
 
 ## Next Steps
 

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,8 @@
 ## Docs
 
 - [Quick Start](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/quickstart.md): Installation, local token setup, and Mattermost OAuth proxy setup
-- [Configuration](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/configuration.md): Environment variables, authentication modes, and Mattermost OAuth App setup
+- [Configuration](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/configuration.md): Environment variables, timeouts, retries, logging, SSL
+- [Authentication](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/authentication.md): Auth modes (static_token, client_token, oauth_proxy), Mattermost OAuth App setup, troubleshooting
 - [Docker](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/docker.md): Docker stdio, HTTP, and OAuth proxy deployment
 - [Channel Tools](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/tools/channels.md): List, create, join channels (9 tools)
 - [Message Tools](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/tools/messages.md): Send, search, edit messages (5 tools)

--- a/llms.txt
+++ b/llms.txt
@@ -1,12 +1,13 @@
 # Mattermost MCP Server
 
-> MCP server providing 36 tools for Mattermost integration:
+> MCP server providing 37 tools for Mattermost integration:
 > channels, messages, reactions, threads, users, teams, files, and bookmarks.
 
 ## Docs
 
-- [Quick Start](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/quickstart.md): Installation and Claude Desktop configuration
-- [Configuration](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/configuration.md): Environment variables and options
+- [Quick Start](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/quickstart.md): Installation, local token setup, and Mattermost OAuth proxy setup
+- [Configuration](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/configuration.md): Environment variables, authentication modes, and Mattermost OAuth App setup
+- [Docker](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/docker.md): Docker stdio, HTTP, and OAuth proxy deployment
 - [Channel Tools](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/tools/channels.md): List, create, join channels (9 tools)
 - [Message Tools](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/tools/messages.md): Send, search, edit messages (5 tools)
 - [Post Tools](https://raw.githubusercontent.com/cloud-ru-tech/mcp-server-mattermost/main/docs/tools/posts.md): Reactions, pins, threads (6 tools)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
   - Home: index.md
   - Quick Start: quickstart.md
   - Configuration: configuration.md
+  - Authentication: authentication.md
   - Docker: docker.md
   - Examples: examples.md
   - Best Practices: best-practices.md

--- a/src/mcp_server_mattermost/auth.py
+++ b/src/mcp_server_mattermost/auth.py
@@ -18,7 +18,8 @@ class MattermostTokenVerifier(TokenVerifier):
     """Validates bearer tokens by calling Mattermost /api/v4/users/me.
 
     Implements FastMCP TokenVerifier ABC. Used as ``auth=`` parameter on
-    the FastMCP server when ``allow_http_client_tokens=True``.
+    the FastMCP server for client-token mode and as the upstream token
+    validator for OAuth proxy mode.
 
     Settings are loaded lazily (on first call to ``verify_token``) so that
     this class can be instantiated at module import time without requiring
@@ -95,7 +96,12 @@ class MattermostTokenVerifier(TokenVerifier):
                 token=token,
                 client_id=user_id,
                 scopes=[],
-                claims={"mattermost_token": token},
+                claims={
+                    "mattermost_token": token,
+                    "mattermost_user_id": user_id,
+                    "mattermost_username": user.get("username"),
+                    "mattermost_email": user.get("email"),
+                },
             )
             self._cache[cache_key] = access_token
             return access_token

--- a/src/mcp_server_mattermost/auth.py
+++ b/src/mcp_server_mattermost/auth.py
@@ -99,8 +99,6 @@ class MattermostTokenVerifier(TokenVerifier):
                 claims={
                     "mattermost_token": token,
                     "mattermost_user_id": user_id,
-                    "mattermost_username": user.get("username"),
-                    "mattermost_email": user.get("email"),
                 },
             )
             self._cache[cache_key] = access_token

--- a/src/mcp_server_mattermost/auth_factory.py
+++ b/src/mcp_server_mattermost/auth_factory.py
@@ -1,6 +1,7 @@
 """FastMCP authentication provider selection."""
 
 from fastmcp.server.auth import AuthProvider
+from typing_extensions import assert_never
 
 from .auth import MattermostTokenVerifier
 from .auth_oauth import build_mattermost_oauth_proxy
@@ -16,15 +17,15 @@ def build_auth_provider(settings: Settings) -> AuthProvider | None:
     Returns:
         Auth provider for HTTP transports, or None for static token mode.
     """
-    if settings.auth_mode is AuthMode.STATIC_TOKEN:
-        return None
-    if settings.auth_mode is AuthMode.CLIENT_TOKEN:
-        return MattermostTokenVerifier()
-    if settings.auth_mode is AuthMode.OAUTH_PROXY:
-        return build_mattermost_oauth_proxy(settings)
-
-    msg = f"Unsupported auth mode: {settings.auth_mode}"
-    raise ValueError(msg)
+    match settings.auth_mode:
+        case AuthMode.STATIC_TOKEN:
+            return None
+        case AuthMode.CLIENT_TOKEN:
+            return MattermostTokenVerifier()
+        case AuthMode.OAUTH_PROXY:
+            return build_mattermost_oauth_proxy(settings)
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 def build_auth_provider_from_env() -> AuthProvider | None:

--- a/src/mcp_server_mattermost/auth_factory.py
+++ b/src/mcp_server_mattermost/auth_factory.py
@@ -1,0 +1,32 @@
+"""FastMCP authentication provider selection."""
+
+from fastmcp.server.auth import AuthProvider
+
+from .auth import MattermostTokenVerifier
+from .auth_oauth import build_mattermost_oauth_proxy
+from .config import AuthMode, Settings, get_settings
+
+
+def build_auth_provider(settings: Settings) -> AuthProvider | None:
+    """Build the FastMCP auth provider for the configured auth mode.
+
+    Args:
+        settings: Validated application settings.
+
+    Returns:
+        Auth provider for HTTP transports, or None for static token mode.
+    """
+    if settings.auth_mode is AuthMode.STATIC_TOKEN:
+        return None
+    if settings.auth_mode is AuthMode.CLIENT_TOKEN:
+        return MattermostTokenVerifier()
+    if settings.auth_mode is AuthMode.OAUTH_PROXY:
+        return build_mattermost_oauth_proxy(settings)
+
+    msg = f"Unsupported auth mode: {settings.auth_mode}"
+    raise ValueError(msg)
+
+
+def build_auth_provider_from_env() -> AuthProvider | None:
+    """Build auth provider from environment-backed settings."""
+    return build_auth_provider(get_settings())

--- a/src/mcp_server_mattermost/auth_oauth.py
+++ b/src/mcp_server_mattermost/auth_oauth.py
@@ -42,6 +42,7 @@ def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
             jwt_signing_key=settings.oauth_jwt_signing_key,
             require_authorization_consent=settings.oauth_require_consent,
             fallback_access_token_expiry_seconds=settings.oauth_fallback_access_token_expiry_seconds,
+            enable_cimd=False,
         )
 
     return OAuthProxy(
@@ -58,4 +59,5 @@ def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
         jwt_signing_key=settings.oauth_jwt_signing_key,
         require_authorization_consent=settings.oauth_require_consent,
         fallback_access_token_expiry_seconds=settings.oauth_fallback_access_token_expiry_seconds,
+        enable_cimd=False,
     )

--- a/src/mcp_server_mattermost/auth_oauth.py
+++ b/src/mcp_server_mattermost/auth_oauth.py
@@ -1,14 +1,19 @@
 """Mattermost OAuthProxy construction."""
 
-import hashlib
-from base64 import urlsafe_b64encode
-from typing import Any
-from urllib.parse import urlencode
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastmcp.server.auth import OAuthProxy
 
 from .auth import MattermostTokenVerifier
 from .config import OAuthClientType, Settings
+
+
+if TYPE_CHECKING:
+    from key_value.aio.protocols import AsyncKeyValue
+    from pydantic import AnyHttpUrl
 
 
 class MattermostOAuthProxy(OAuthProxy):
@@ -20,31 +25,69 @@ class MattermostOAuthProxy(OAuthProxy):
     we intentionally do not forward it upstream.
     """
 
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        upstream_authorization_endpoint: str,
+        upstream_token_endpoint: str,
+        upstream_client_id: str,
+        upstream_client_secret: str,
+        mattermost_verifier: MattermostTokenVerifier,
+        base_url: AnyHttpUrl | str,
+        upstream_revocation_endpoint: str | None = None,
+        redirect_path: str | None = None,
+        issuer_url: AnyHttpUrl | str | None = None,
+        service_documentation_url: AnyHttpUrl | str | None = None,
+        allowed_client_redirect_uris: list[str] | None = None,
+        valid_scopes: list[str] | None = None,
+        forward_pkce: bool = True,
+        token_endpoint_auth_method: str | None = None,
+        extra_authorize_params: dict[str, str] | None = None,
+        extra_token_params: dict[str, str] | None = None,
+        client_storage: AsyncKeyValue | None = None,
+        jwt_signing_key: str | bytes | None = None,
+        require_authorization_consent: bool = True,
+        consent_csp_policy: str | None = None,
+        fallback_access_token_expiry_seconds: int | None = None,
+        enable_cimd: bool = True,
+    ) -> None:
+        """Initialize proxy and keep explicit ownership of the Mattermost verifier."""
+        super().__init__(
+            upstream_authorization_endpoint=upstream_authorization_endpoint,
+            upstream_token_endpoint=upstream_token_endpoint,
+            upstream_client_id=upstream_client_id,
+            upstream_client_secret=upstream_client_secret,
+            upstream_revocation_endpoint=upstream_revocation_endpoint,
+            token_verifier=mattermost_verifier,
+            base_url=base_url,
+            redirect_path=redirect_path,
+            issuer_url=issuer_url,
+            service_documentation_url=service_documentation_url,
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
+            valid_scopes=valid_scopes,
+            forward_pkce=forward_pkce,
+            token_endpoint_auth_method=token_endpoint_auth_method,
+            extra_authorize_params=extra_authorize_params,
+            extra_token_params=extra_token_params,
+            client_storage=client_storage,
+            jwt_signing_key=jwt_signing_key,
+            require_authorization_consent=require_authorization_consent,
+            consent_csp_policy=consent_csp_policy,
+            fallback_access_token_expiry_seconds=fallback_access_token_expiry_seconds,
+            enable_cimd=enable_cimd,
+        )
+        self._mattermost_verifier = mattermost_verifier
+
     def _build_upstream_authorize_url(self, txn_id: str, transaction: dict[str, Any]) -> str:
         """Construct the Mattermost authorize URL without RFC8707 resource."""
-        query_params: dict[str, Any] = {
-            "response_type": "code",
-            "client_id": self._upstream_client_id,
-            "redirect_uri": f"{str(self.base_url).rstrip('/')}{self._redirect_path}",
-            "state": txn_id,
-        }
+        url = super()._build_upstream_authorize_url(txn_id, transaction)
+        parts = urlsplit(url)
+        query = [(key, value) for key, value in parse_qsl(parts.query, keep_blank_values=True) if key != "resource"]
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
 
-        scopes_to_use = transaction.get("scopes") or self.required_scopes or []
-        if scopes_to_use:
-            query_params["scope"] = " ".join(scopes_to_use)
-
-        proxy_code_verifier = transaction.get("proxy_code_verifier")
-        if proxy_code_verifier:
-            challenge_bytes = hashlib.sha256(proxy_code_verifier.encode()).digest()
-            proxy_code_challenge = urlsafe_b64encode(challenge_bytes).decode().rstrip("=")
-            query_params["code_challenge"] = proxy_code_challenge
-            query_params["code_challenge_method"] = "S256"
-
-        if self._extra_authorize_params:
-            query_params.update(self._extra_authorize_params)
-
-        separator = "&" if "?" in self._upstream_authorization_endpoint else "?"
-        return f"{self._upstream_authorization_endpoint}{separator}{urlencode(query_params)}"
+    async def close(self) -> None:
+        """Close the owned Mattermost token verifier."""
+        await self._mattermost_verifier.close()
 
 
 def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
@@ -67,38 +110,30 @@ def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
         raise ValueError(msg)
 
     mattermost_public_url = settings.oauth_mattermost_public_url or settings.url
+    common_kwargs: dict[str, Any] = {
+        "upstream_authorization_endpoint": f"{mattermost_public_url}/oauth/authorize",
+        "upstream_token_endpoint": f"{settings.url}/oauth/access_token",
+        "upstream_client_id": settings.oauth_client_id,
+        "mattermost_verifier": MattermostTokenVerifier(),
+        "base_url": settings.oauth_mcp_public_url,
+        "redirect_path": settings.oauth_callback_path,
+        "allowed_client_redirect_uris": settings.oauth_allowed_redirect_uris,
+        "forward_pkce": True,
+        "jwt_signing_key": settings.oauth_jwt_signing_key,
+        "require_authorization_consent": settings.oauth_require_consent,
+        "fallback_access_token_expiry_seconds": settings.oauth_fallback_access_token_expiry_seconds,
+        "enable_cimd": False,
+    }
 
     if settings.oauth_client_type is OAuthClientType.PUBLIC:
         return MattermostOAuthProxy(
-            upstream_authorization_endpoint=f"{mattermost_public_url}/oauth/authorize",
-            upstream_token_endpoint=f"{settings.url}/oauth/access_token",
-            upstream_client_id=settings.oauth_client_id,
+            **common_kwargs,
             upstream_client_secret="",
-            token_verifier=MattermostTokenVerifier(),
-            base_url=settings.oauth_mcp_public_url,
-            redirect_path=settings.oauth_callback_path,
-            allowed_client_redirect_uris=settings.oauth_allowed_redirect_uris,
-            forward_pkce=True,
             token_endpoint_auth_method="none",  # noqa: S106
-            jwt_signing_key=settings.oauth_jwt_signing_key,
-            require_authorization_consent=settings.oauth_require_consent,
-            fallback_access_token_expiry_seconds=settings.oauth_fallback_access_token_expiry_seconds,
-            enable_cimd=False,
         )
 
     return MattermostOAuthProxy(
-        upstream_authorization_endpoint=f"{mattermost_public_url}/oauth/authorize",
-        upstream_token_endpoint=f"{settings.url}/oauth/access_token",
-        upstream_client_id=settings.oauth_client_id,
+        **common_kwargs,
         upstream_client_secret=settings.oauth_client_secret or "",
-        token_verifier=MattermostTokenVerifier(),
-        base_url=settings.oauth_mcp_public_url,
-        redirect_path=settings.oauth_callback_path,
-        allowed_client_redirect_uris=settings.oauth_allowed_redirect_uris,
-        forward_pkce=True,
         token_endpoint_auth_method="client_secret_post",  # noqa: S106
-        jwt_signing_key=settings.oauth_jwt_signing_key,
-        require_authorization_consent=settings.oauth_require_consent,
-        fallback_access_token_expiry_seconds=settings.oauth_fallback_access_token_expiry_seconds,
-        enable_cimd=False,
     )

--- a/src/mcp_server_mattermost/auth_oauth.py
+++ b/src/mcp_server_mattermost/auth_oauth.py
@@ -1,0 +1,61 @@
+"""Mattermost OAuthProxy construction."""
+
+from fastmcp.server.auth import OAuthProxy
+
+from .auth import MattermostTokenVerifier
+from .config import OAuthClientType, Settings
+
+
+def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
+    """Build a FastMCP OAuthProxy configured for Mattermost OAuth.
+
+    Args:
+        settings: Validated application settings.
+
+    Returns:
+        Configured FastMCP OAuthProxy instance.
+
+    Raises:
+        ValueError: If oauth_proxy settings are missing.
+    """
+    if not settings.oauth_mcp_public_url:
+        msg = "oauth_mcp_public_url is required"
+        raise ValueError(msg)
+    if not settings.oauth_client_id:
+        msg = "oauth_client_id is required"
+        raise ValueError(msg)
+
+    mattermost_public_url = settings.oauth_mattermost_public_url or settings.url
+
+    if settings.oauth_client_type is OAuthClientType.PUBLIC:
+        return OAuthProxy(
+            upstream_authorization_endpoint=f"{mattermost_public_url}/oauth/authorize",
+            upstream_token_endpoint=f"{settings.url}/oauth/access_token",
+            upstream_client_id=settings.oauth_client_id,
+            upstream_client_secret="",
+            token_verifier=MattermostTokenVerifier(),
+            base_url=settings.oauth_mcp_public_url,
+            redirect_path=settings.oauth_callback_path,
+            allowed_client_redirect_uris=settings.oauth_allowed_redirect_uris,
+            forward_pkce=True,
+            token_endpoint_auth_method="none",  # noqa: S106
+            jwt_signing_key=settings.oauth_jwt_signing_key,
+            require_authorization_consent=settings.oauth_require_consent,
+            fallback_access_token_expiry_seconds=settings.oauth_fallback_access_token_expiry_seconds,
+        )
+
+    return OAuthProxy(
+        upstream_authorization_endpoint=f"{mattermost_public_url}/oauth/authorize",
+        upstream_token_endpoint=f"{settings.url}/oauth/access_token",
+        upstream_client_id=settings.oauth_client_id,
+        upstream_client_secret=settings.oauth_client_secret or "",
+        token_verifier=MattermostTokenVerifier(),
+        base_url=settings.oauth_mcp_public_url,
+        redirect_path=settings.oauth_callback_path,
+        allowed_client_redirect_uris=settings.oauth_allowed_redirect_uris,
+        forward_pkce=True,
+        token_endpoint_auth_method="client_secret_post",  # noqa: S106
+        jwt_signing_key=settings.oauth_jwt_signing_key,
+        require_authorization_consent=settings.oauth_require_consent,
+        fallback_access_token_expiry_seconds=settings.oauth_fallback_access_token_expiry_seconds,
+    )

--- a/src/mcp_server_mattermost/auth_oauth.py
+++ b/src/mcp_server_mattermost/auth_oauth.py
@@ -1,9 +1,50 @@
 """Mattermost OAuthProxy construction."""
 
+import hashlib
+from base64 import urlsafe_b64encode
+from typing import Any
+from urllib.parse import urlencode
+
 from fastmcp.server.auth import OAuthProxy
 
 from .auth import MattermostTokenVerifier
 from .config import OAuthClientType, Settings
+
+
+class MattermostOAuthProxy(OAuthProxy):
+    """OAuthProxy variant for Mattermost's OAuth service provider.
+
+    FastMCP validates the MCP client's RFC8707 resource indicator locally and
+    stores it in the transaction. Mattermost does not advertise resource
+    indicator support and rejects the extra parameter on /oauth/authorize, so
+    we intentionally do not forward it upstream.
+    """
+
+    def _build_upstream_authorize_url(self, txn_id: str, transaction: dict[str, Any]) -> str:
+        """Construct the Mattermost authorize URL without RFC8707 resource."""
+        query_params: dict[str, Any] = {
+            "response_type": "code",
+            "client_id": self._upstream_client_id,
+            "redirect_uri": f"{str(self.base_url).rstrip('/')}{self._redirect_path}",
+            "state": txn_id,
+        }
+
+        scopes_to_use = transaction.get("scopes") or self.required_scopes or []
+        if scopes_to_use:
+            query_params["scope"] = " ".join(scopes_to_use)
+
+        proxy_code_verifier = transaction.get("proxy_code_verifier")
+        if proxy_code_verifier:
+            challenge_bytes = hashlib.sha256(proxy_code_verifier.encode()).digest()
+            proxy_code_challenge = urlsafe_b64encode(challenge_bytes).decode().rstrip("=")
+            query_params["code_challenge"] = proxy_code_challenge
+            query_params["code_challenge_method"] = "S256"
+
+        if self._extra_authorize_params:
+            query_params.update(self._extra_authorize_params)
+
+        separator = "&" if "?" in self._upstream_authorization_endpoint else "?"
+        return f"{self._upstream_authorization_endpoint}{separator}{urlencode(query_params)}"
 
 
 def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
@@ -28,7 +69,7 @@ def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
     mattermost_public_url = settings.oauth_mattermost_public_url or settings.url
 
     if settings.oauth_client_type is OAuthClientType.PUBLIC:
-        return OAuthProxy(
+        return MattermostOAuthProxy(
             upstream_authorization_endpoint=f"{mattermost_public_url}/oauth/authorize",
             upstream_token_endpoint=f"{settings.url}/oauth/access_token",
             upstream_client_id=settings.oauth_client_id,
@@ -45,7 +86,7 @@ def build_mattermost_oauth_proxy(settings: Settings) -> OAuthProxy:
             enable_cimd=False,
         )
 
-    return OAuthProxy(
+    return MattermostOAuthProxy(
         upstream_authorization_endpoint=f"{mattermost_public_url}/oauth/authorize",
         upstream_token_endpoint=f"{settings.url}/oauth/access_token",
         upstream_client_id=settings.oauth_client_id,

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -1,9 +1,28 @@
 """Configuration management using Pydantic Settings."""
 
+from enum import Enum
 from functools import lru_cache
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AuthMode(str, Enum):
+    """Mattermost authentication mode."""
+
+    STATIC_TOKEN = "static_token"  # noqa: S105
+    CLIENT_TOKEN = "client_token"  # noqa: S105
+    OAUTH_PROXY = "oauth_proxy"
+
+
+class OAuthClientType(str, Enum):
+    """Mattermost OAuth application client type."""
+
+    PUBLIC = "public"
+    CONFIDENTIAL = "confidential"
+
+
+_LOCALHOST_PREFIXES = ("http://localhost", "http://127.0.0.1", "http://[::1]")
 
 
 class Settings(BaseSettings):
@@ -11,8 +30,15 @@ class Settings(BaseSettings):
 
     Environment variables:
         MATTERMOST_URL: Mattermost server URL (required)
-        MATTERMOST_TOKEN: Bot/user access token (required unless allow_http_client_tokens)
-        MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS: Allow token from Authorization header in HTTP/SSE (default: false)
+        MATTERMOST_AUTH_MODE: static_token, client_token, or oauth_proxy
+        MATTERMOST_TOKEN: Bot/user access token (required for static_token)
+        MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS: Deprecated alias for MATTERMOST_AUTH_MODE=client_token
+        MATTERMOST_OAUTH_CLIENT_ID: Mattermost OAuth App client ID for oauth_proxy
+        MATTERMOST_OAUTH_CLIENT_TYPE: public or confidential for oauth_proxy
+        MATTERMOST_OAUTH_CLIENT_SECRET: Mattermost OAuth App secret for confidential oauth_proxy
+        MATTERMOST_OAUTH_JWT_SIGNING_KEY: FastMCP JWT signing key for oauth_proxy
+        MATTERMOST_OAUTH_MCP_PUBLIC_URL: Public base URL of this MCP server
+        MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL: Browser-facing Mattermost URL
         MATTERMOST_TIMEOUT: Request timeout in seconds (default: 30)
         MATTERMOST_MAX_RETRIES: Max retry attempts (default: 3)
         MATTERMOST_VERIFY_SSL: Verify SSL certificates (default: true)
@@ -29,10 +55,11 @@ class Settings(BaseSettings):
     )
 
     url: str = Field(description="Mattermost server URL")
-    token: str | None = Field(default=None, description="Bot or user access token (required for STDIO)")
+    token: str | None = Field(default=None, description="Bot or user access token")
+    auth_mode: AuthMode = Field(default=AuthMode.STATIC_TOKEN, description="Authentication mode")
     allow_http_client_tokens: bool = Field(
         default=False,
-        description="Allow token from Authorization: Bearer in HTTP/SSE; ignored for STDIO",
+        description="Deprecated alias for auth_mode=client_token",
     )
     timeout: int = Field(default=30, ge=1, le=300, description="Request timeout in seconds")
     max_retries: int = Field(default=3, ge=0, le=10, description="Maximum retry attempts")
@@ -41,10 +68,36 @@ class Settings(BaseSettings):
     log_format: str = Field(default="json", description="Log format: 'json' or 'text'")
     api_version: str = Field(default="v4", description="Mattermost API version")
 
-    @field_validator("url")
+    oauth_client_id: str | None = Field(default=None, description="Mattermost OAuth App client ID")
+    oauth_client_type: OAuthClientType = Field(
+        default=OAuthClientType.CONFIDENTIAL,
+        description="Mattermost OAuth App client type",
+    )
+    oauth_client_secret: str | None = Field(default=None, description="Mattermost OAuth App client secret")
+    oauth_callback_path: str = Field(default="/oauth/callback/mm", description="OAuth callback path")
+    oauth_jwt_signing_key: str | None = Field(default=None, description="FastMCP JWT signing key")
+    oauth_mcp_public_url: str | None = Field(default=None, description="Public base URL of this MCP server")
+    oauth_mattermost_public_url: str | None = Field(
+        default=None,
+        description="Browser-facing Mattermost URL for OAuth redirects",
+    )
+    oauth_allowed_redirect_uris: list[str] = Field(
+        default_factory=lambda: ["http://localhost:*", "http://127.0.0.1:*"],
+        description="Allowed MCP client redirect URI patterns",
+    )
+    oauth_require_consent: bool = Field(default=True, description="Require FastMCP consent screen")
+    oauth_fallback_access_token_expiry_seconds: int | None = Field(
+        default=None,
+        ge=1,
+        description="Fallback access token TTL when Mattermost omits expires_in",
+    )
+
+    @field_validator("url", "oauth_mcp_public_url", "oauth_mattermost_public_url")
     @classmethod
-    def validate_url(cls, v: str) -> str:
+    def validate_url(cls, v: str | None) -> str | None:
         """Remove trailing slash."""
+        if v is None:
+            return v
         return v.rstrip("/")
 
     @field_validator("log_level")
@@ -69,13 +122,57 @@ class Settings(BaseSettings):
             raise ValueError(msg)
         return lower
 
-    @model_validator(mode="after")
-    def require_token_unless_http_client_tokens(self) -> "Settings":
-        """Require MATTERMOST_TOKEN when allow_http_client_tokens is False (STDIO always needs it)."""
-        if not self.allow_http_client_tokens and not (self.token and self.token.strip()):
-            msg = "MATTERMOST_TOKEN is required when MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS is false"
+    @field_validator("oauth_callback_path")
+    @classmethod
+    def validate_oauth_callback_path(cls, v: str) -> str:
+        """Ensure OAuth callback path is absolute."""
+        if not v.startswith("/"):
+            msg = "MATTERMOST_OAUTH_CALLBACK_PATH must start with '/'"
             raise ValueError(msg)
+        return v
+
+    @model_validator(mode="after")
+    def validate_auth_configuration(self) -> "Settings":
+        """Validate mode-specific authentication settings."""
+        if self.allow_http_client_tokens:
+            if "auth_mode" not in self.model_fields_set:
+                self.auth_mode = AuthMode.CLIENT_TOKEN
+            elif self.auth_mode is not AuthMode.CLIENT_TOKEN:
+                msg = "MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS conflicts with MATTERMOST_AUTH_MODE"
+                raise ValueError(msg)
+
+        if self.auth_mode is AuthMode.STATIC_TOKEN and not (self.token and self.token.strip()):
+            msg = "MATTERMOST_TOKEN is required when MATTERMOST_AUTH_MODE=static_token"
+            raise ValueError(msg)
+
+        if self.auth_mode is AuthMode.OAUTH_PROXY:
+            self._validate_oauth_proxy()
+
         return self
+
+    def _validate_oauth_proxy(self) -> None:
+        """Validate oauth_proxy-specific settings."""
+        if not self.oauth_mcp_public_url:
+            msg = "MATTERMOST_OAUTH_MCP_PUBLIC_URL is required when MATTERMOST_AUTH_MODE=oauth_proxy"
+            raise ValueError(msg)
+        if not self.oauth_client_id:
+            msg = "MATTERMOST_OAUTH_CLIENT_ID is required when MATTERMOST_AUTH_MODE=oauth_proxy"
+            raise ValueError(msg)
+        if self.oauth_client_type is OAuthClientType.PUBLIC and not (
+            self.oauth_jwt_signing_key and self.oauth_jwt_signing_key.strip()
+        ):
+            msg = "MATTERMOST_OAUTH_JWT_SIGNING_KEY is required for public OAuth clients"
+            raise ValueError(msg)
+        if self.oauth_client_type is OAuthClientType.CONFIDENTIAL and not (
+            self.oauth_client_secret and self.oauth_client_secret.strip()
+        ):
+            msg = "MATTERMOST_OAUTH_CLIENT_SECRET is required for confidential OAuth clients"
+            raise ValueError(msg)
+        if not self.oauth_mcp_public_url.startswith("https://") and not self.oauth_mcp_public_url.startswith(
+            _LOCALHOST_PREFIXES
+        ):
+            msg = "MATTERMOST_OAUTH_MCP_PUBLIC_URL must use HTTPS unless it is localhost"
+            raise ValueError(msg)
 
 
 @lru_cache

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from functools import lru_cache
+from urllib.parse import urlsplit
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -22,7 +23,13 @@ class OAuthClientType(str, Enum):
     CONFIDENTIAL = "confidential"
 
 
-_LOCALHOST_PREFIXES = ("http://localhost", "http://127.0.0.1", "http://[::1]")
+_LOCALHOST_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _uses_https_or_localhost(url: str) -> bool:
+    """Return whether URL is HTTPS or points at localhost."""
+    parts = urlsplit(url)
+    return parts.scheme == "https" or parts.hostname in _LOCALHOST_HOSTS
 
 
 class Settings(BaseSettings):
@@ -168,10 +175,15 @@ class Settings(BaseSettings):
         ):
             msg = "MATTERMOST_OAUTH_CLIENT_SECRET is required for confidential OAuth clients"
             raise ValueError(msg)
-        if not self.oauth_mcp_public_url.startswith("https://") and not self.oauth_mcp_public_url.startswith(
-            _LOCALHOST_PREFIXES
-        ):
+        if not _uses_https_or_localhost(self.oauth_mcp_public_url):
             msg = "MATTERMOST_OAUTH_MCP_PUBLIC_URL must use HTTPS unless it is localhost"
+            raise ValueError(msg)
+        browser_facing_mattermost_url = self.oauth_mattermost_public_url or self.url
+        if not _uses_https_or_localhost(browser_facing_mattermost_url):
+            msg = (
+                "Browser-facing Mattermost URL must use HTTPS unless it is localhost. "
+                "Set MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL to an HTTPS URL or use HTTPS for MATTERMOST_URL."
+            )
             raise ValueError(msg)
 
 

--- a/src/mcp_server_mattermost/deps.py
+++ b/src/mcp_server_mattermost/deps.py
@@ -6,22 +6,27 @@ from contextlib import asynccontextmanager
 from fastmcp.server.dependencies import get_access_token
 
 from .client import MattermostClient
-from .config import get_settings
+from .config import AuthMode, get_settings
+from .exceptions import AuthenticationError
+
+
+def _get_mattermost_token_from_auth_context() -> str:
+    """Return Mattermost token from FastMCP auth context.
+
+    Raises:
+        AuthenticationError: If no validated Mattermost token is available.
+    """
+    access_token = get_access_token()
+    token = access_token.claims.get("mattermost_token") if access_token is not None else None
+    if not isinstance(token, str) or not token.strip():
+        msg = "Mattermost token is required for this auth mode"
+        raise AuthenticationError(msg)
+    return token
 
 
 @asynccontextmanager
 async def get_client() -> AsyncIterator[MattermostClient]:
     """Provide Mattermost client with automatic lifecycle management.
-
-    Token selection logic:
-        - STDIO transport: ``get_access_token()`` returns ``None``; falls back to
-          ``settings.token`` (``MATTERMOST_TOKEN`` env var).
-        - HTTP transport with ``allow_http_client_tokens=True``: FastMCP validates
-          the bearer token via ``MattermostTokenVerifier`` before this runs;
-          ``get_access_token()`` returns the validated ``AccessToken`` whose
-          ``claims["mattermost_token"]`` holds the original Mattermost token.
-        - HTTP transport with ``allow_http_client_tokens=False``: flag is ``False``,
-          so the access token is ignored; ``settings.token`` is used.
 
     Yields:
         MattermostClient ready for API calls
@@ -29,10 +34,8 @@ async def get_client() -> AsyncIterator[MattermostClient]:
     settings = get_settings()
     token: str | None = None
 
-    if settings.allow_http_client_tokens:
-        access_token = get_access_token()
-        if access_token is not None:
-            token = access_token.claims.get("mattermost_token")
+    if settings.auth_mode in {AuthMode.CLIENT_TOKEN, AuthMode.OAUTH_PROXY}:
+        token = _get_mattermost_token_from_auth_context()
 
     client = MattermostClient(settings, token=token)
     async with client.lifespan():

--- a/src/mcp_server_mattermost/server.py
+++ b/src/mcp_server_mattermost/server.py
@@ -1,23 +1,18 @@
 """FastMCP server for Mattermost integration."""
 
-import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 
 from fastmcp import FastMCP
 from fastmcp.server.lifespan import lifespan
 from fastmcp.server.providers import FileSystemProvider
-from pydantic import TypeAdapter
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from .auth import MattermostTokenVerifier
+from .auth_factory import build_auth_provider_from_env
 from .config import get_settings
 from .logging import logger, setup_logging
 from .middleware import LoggingMiddleware
-
-
-_ALLOW_HTTP_CLIENT_TOKENS_ADAPTER: TypeAdapter[bool] = TypeAdapter(bool)
 
 
 @lifespan
@@ -43,27 +38,15 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[dict[str, object]]:
 
 
 def _create_mcp() -> FastMCP:
-    """Create FastMCP instance with optional Mattermost token authentication.
+    """Create FastMCP instance with configured authentication.
 
-    Reads ``MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS`` directly from the environment
-    (without full pydantic validation) so the module can be safely imported
-    before ``MATTERMOST_URL`` and ``MATTERMOST_TOKEN`` are configured.
-    Full settings validation happens inside the lifespan and ``verify_token``.
-
-    When the flag is ``true``, attaches a ``MattermostTokenVerifier`` that
-    validates bearer tokens against the Mattermost API before allowing tool access.
-
-    Warning:
-        This reads ``os.getenv``, not pydantic-settings, so ``.env`` files are
-        not consulted for this variable. It must be set in the actual OS
-        environment (export, Docker -e, systemd Environment=, etc.).
+    Settings are loaded through pydantic-settings so auth mode selection is
+    validated consistently across stdio and HTTP transports.
 
     Returns:
         Configured FastMCP server instance
     """
-    raw = os.getenv("MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS", "false")
-    allow_http = _ALLOW_HTTP_CLIENT_TOKENS_ADAPTER.validate_python(raw)
-    auth: MattermostTokenVerifier | None = MattermostTokenVerifier() if allow_http else None
+    auth = build_auth_provider_from_env()
     return FastMCP(
         name="Mattermost",
         instructions="MCP server for Mattermost team collaboration platform",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,11 @@ def mock_settings(monkeypatch):
 
 @pytest.fixture
 def mock_settings_allow_http(monkeypatch):
-    """Set env vars with allow_http_client_tokens=True (no MATTERMOST_TOKEN required)."""
+    """Set env vars with auth_mode=client_token (no MATTERMOST_TOKEN required)."""
     from mcp_server_mattermost.config import get_settings
 
     get_settings.cache_clear()
     monkeypatch.setenv("MATTERMOST_URL", "http://mattermost.example.com")
-    monkeypatch.setenv("MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS", "true")
+    monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
     yield
     get_settings.cache_clear()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,6 @@ from _pytest.monkeypatch import MonkeyPatch
 from fastmcp import Client
 
 from mcp_server_mattermost.config import get_settings
-from mcp_server_mattermost.server import mcp
 
 from .utils import cleanup_channel, make_test_name, setup_docker_host, to_dict
 
@@ -150,6 +149,8 @@ async def mcp_client(mattermost_env):
     - MattermostClient HTTP logic
     - Real Mattermost API
     """
+    from mcp_server_mattermost.server import mcp
+
     async with Client(mcp) as client:
         yield client
 
@@ -161,6 +162,8 @@ def session_mcp_client_sync(mattermost_env, event_loop):
     Uses a more robust pattern that properly handles exceptions during cleanup.
     """
     import warnings
+
+    from mcp_server_mattermost.server import mcp
 
     client = None
     cleanup_exc = None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,8 +29,8 @@ class TestMattermostTokenVerifier:
         assert result.claims["mattermost_token"] == "valid-token-abc"
 
     @pytest.mark.asyncio
-    async def test_valid_token_includes_user_claims(self, mock_settings: None) -> None:
-        """Valid Mattermost token includes useful Mattermost user claims."""
+    async def test_valid_token_includes_minimal_user_claims(self, mock_settings: None) -> None:
+        """Valid Mattermost token exposes only claims needed by production code."""
         from mcp_server_mattermost.auth import MattermostTokenVerifier
         from mcp_server_mattermost.config import get_settings
 
@@ -47,10 +47,7 @@ class TestMattermostTokenVerifier:
             result = await verifier.verify_token("valid-token-abc")
 
         assert result is not None
-        assert result.claims["mattermost_token"] == "valid-token-abc"
-        assert result.claims["mattermost_user_id"] == "user123"
-        assert result.claims["mattermost_username"] == "alice"
-        assert result.claims["mattermost_email"] == "alice@example.com"
+        assert result.claims == {"mattermost_token": "valid-token-abc", "mattermost_user_id": "user123"}
 
     @pytest.mark.asyncio
     async def test_invalid_token_returns_none(self, mock_settings: None) -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,6 +29,30 @@ class TestMattermostTokenVerifier:
         assert result.claims["mattermost_token"] == "valid-token-abc"
 
     @pytest.mark.asyncio
+    async def test_valid_token_includes_user_claims(self, mock_settings: None) -> None:
+        """Valid Mattermost token includes useful Mattermost user claims."""
+        from mcp_server_mattermost.auth import MattermostTokenVerifier
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        verifier = MattermostTokenVerifier()
+
+        with respx.mock:
+            respx.get(f"{settings.url}/api/v4/users/me").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"id": "user123", "username": "alice", "email": "alice@example.com"},
+                )
+            )
+            result = await verifier.verify_token("valid-token-abc")
+
+        assert result is not None
+        assert result.claims["mattermost_token"] == "valid-token-abc"
+        assert result.claims["mattermost_user_id"] == "user123"
+        assert result.claims["mattermost_username"] == "alice"
+        assert result.claims["mattermost_email"] == "alice@example.com"
+
+    @pytest.mark.asyncio
     async def test_invalid_token_returns_none(self, mock_settings: None) -> None:
         """Invalid Mattermost token (401) returns None."""
         from mcp_server_mattermost.auth import MattermostTokenVerifier

--- a/tests/test_auth_factory.py
+++ b/tests/test_auth_factory.py
@@ -33,6 +33,7 @@ def test_build_auth_provider_oauth_proxy_delegates_to_builder() -> None:
         oauth_client_id="mm-client",
         oauth_jwt_signing_key="signing-key-1234567890",
         oauth_mcp_public_url="http://localhost:8000",
+        oauth_mattermost_public_url="https://mattermost.example.com",
     )
 
     sentinel = object()

--- a/tests/test_auth_factory.py
+++ b/tests/test_auth_factory.py
@@ -1,0 +1,62 @@
+"""Tests for FastMCP auth provider selection."""
+
+from unittest.mock import patch
+
+
+def test_build_auth_provider_static_token_returns_none() -> None:
+    from mcp_server_mattermost.auth_factory import build_auth_provider
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(url="http://mm.example.com", token="static-token")
+
+    assert build_auth_provider(settings) is None
+
+
+def test_build_auth_provider_client_token_returns_verifier() -> None:
+    from mcp_server_mattermost.auth import MattermostTokenVerifier
+    from mcp_server_mattermost.auth_factory import build_auth_provider
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(url="http://mm.example.com", auth_mode="client_token")
+
+    assert isinstance(build_auth_provider(settings), MattermostTokenVerifier)
+
+
+def test_build_auth_provider_oauth_proxy_delegates_to_builder() -> None:
+    from mcp_server_mattermost.auth_factory import build_auth_provider
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="http://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="public",
+        oauth_client_id="mm-client",
+        oauth_jwt_signing_key="signing-key-1234567890",
+        oauth_mcp_public_url="http://localhost:8000",
+    )
+
+    sentinel = object()
+    with patch("mcp_server_mattermost.auth_factory.build_mattermost_oauth_proxy", return_value=sentinel) as builder:
+        result = build_auth_provider(settings)
+
+    assert result is sentinel
+    builder.assert_called_once_with(settings)
+
+
+def test_build_auth_provider_from_env_uses_legacy_flag() -> None:
+    import os
+
+    from mcp_server_mattermost.auth import MattermostTokenVerifier
+    from mcp_server_mattermost.auth_factory import build_auth_provider_from_env
+    from mcp_server_mattermost.config import get_settings
+
+    with patch.dict(
+        os.environ,
+        {"MATTERMOST_URL": "http://mm.example.com", "MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS": "true"},
+        clear=True,
+    ):
+        get_settings.cache_clear()
+        provider = build_auth_provider_from_env()
+        get_settings.cache_clear()
+
+    assert isinstance(provider, MattermostTokenVerifier)

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -1,0 +1,98 @@
+"""Tests for Mattermost OAuthProxy construction."""
+
+from unittest.mock import patch
+
+from fastmcp.server.auth import OAuthProxy
+
+
+def test_build_public_oauth_proxy_uses_public_client_settings() -> None:
+    from mcp_server_mattermost.auth_oauth import build_mattermost_oauth_proxy
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="http://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="public",
+        oauth_client_id="mm-client",
+        oauth_jwt_signing_key="signing-key-1234567890",
+        oauth_mcp_public_url="http://localhost:8000",
+        oauth_mattermost_public_url="http://localhost:8065",
+        oauth_require_consent=False,
+        oauth_allowed_redirect_uris=["http://localhost:*"],
+        oauth_fallback_access_token_expiry_seconds=3600,
+    )
+
+    auth = build_mattermost_oauth_proxy(settings)
+
+    assert isinstance(auth, OAuthProxy)
+    assert auth._upstream_authorization_endpoint == "http://localhost:8065/oauth/authorize"
+    assert auth._upstream_token_endpoint == "http://mattermost.internal/oauth/access_token"
+    assert auth._upstream_client_id == "mm-client"
+    assert auth._upstream_client_secret.get_secret_value() == ""
+    assert auth._token_endpoint_auth_method == "none"
+    assert auth._redirect_path == "/oauth/callback/mm"
+    assert auth._forward_pkce is True
+    assert auth._allowed_client_redirect_uris == ["http://localhost:*"]
+    assert auth._fallback_access_token_expiry_seconds == 3600
+
+
+def test_build_confidential_oauth_proxy_uses_secret_post() -> None:
+    from mcp_server_mattermost.auth_oauth import build_mattermost_oauth_proxy
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="https://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="confidential",
+        oauth_client_id="mm-client",
+        oauth_client_secret="mm-secret",
+        oauth_mcp_public_url="https://mcp.example.com",
+        oauth_callback_path="/custom/callback",
+    )
+
+    auth = build_mattermost_oauth_proxy(settings)
+
+    assert isinstance(auth, OAuthProxy)
+    assert auth._upstream_authorization_endpoint == "https://mattermost.internal/oauth/authorize"
+    assert auth._upstream_token_endpoint == "https://mattermost.internal/oauth/access_token"
+    assert auth._upstream_client_secret.get_secret_value() == "mm-secret"
+    assert auth._token_endpoint_auth_method == "client_secret_post"
+    assert auth._redirect_path == "/custom/callback"
+
+
+def test_build_oauth_proxy_uses_mattermost_token_verifier() -> None:
+    from mcp_server_mattermost.auth import MattermostTokenVerifier
+    from mcp_server_mattermost.auth_oauth import build_mattermost_oauth_proxy
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="https://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="confidential",
+        oauth_client_id="mm-client",
+        oauth_client_secret="mm-secret",
+        oauth_mcp_public_url="https://mcp.example.com",
+    )
+
+    auth = build_mattermost_oauth_proxy(settings)
+
+    assert isinstance(auth._token_validator, MattermostTokenVerifier)
+
+
+def test_build_public_oauth_proxy_passes_explicit_signing_key() -> None:
+    from mcp_server_mattermost.auth_oauth import build_mattermost_oauth_proxy
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="http://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="public",
+        oauth_client_id="mm-client",
+        oauth_jwt_signing_key="signing-key-1234567890",
+        oauth_mcp_public_url="http://localhost:8000",
+    )
+
+    with patch("mcp_server_mattermost.auth_oauth.OAuthProxy") as proxy_cls:
+        build_mattermost_oauth_proxy(settings)
+
+    assert proxy_cls.call_args.kwargs["jwt_signing_key"] == "signing-key-1234567890"

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import pytest
 from fastmcp.server.auth import OAuthProxy
 
 
@@ -91,6 +92,7 @@ def test_build_public_oauth_proxy_passes_explicit_signing_key() -> None:
         oauth_client_id="mm-client",
         oauth_jwt_signing_key="signing-key-1234567890",
         oauth_mcp_public_url="http://localhost:8000",
+        oauth_mattermost_public_url="https://mattermost.example.com",
     )
 
     with patch("mcp_server_mattermost.auth_oauth.MattermostOAuthProxy") as proxy_cls:
@@ -129,3 +131,74 @@ def test_mattermost_oauth_proxy_does_not_forward_resource_to_upstream_authorize(
     assert query["client_id"] == ["mm-client"]
     assert query["redirect_uri"] == ["https://mcp.example.com/mattermost/oauth/callback/mm"]
     assert "resource" not in query
+
+
+def test_mattermost_oauth_proxy_strips_only_resource_from_parent_authorize_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mattermost-specific override should preserve upstream FastMCP authorize behavior."""
+    from mcp_server_mattermost.auth_oauth import build_mattermost_oauth_proxy
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="https://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="public",
+        oauth_client_id="mm-client",
+        oauth_jwt_signing_key="signing-key-1234567890",
+        oauth_mcp_public_url="https://mcp.example.com",
+        oauth_mattermost_public_url="https://mm.example.com",
+    )
+    auth = build_mattermost_oauth_proxy(settings)
+
+    def build_parent_url(self: OAuthProxy, txn_id: str, transaction: dict[str, object]) -> str:
+        assert txn_id == "txn-id"
+        assert transaction["resource"] == "https://mcp.example.com/mcp"
+        return (
+            "https://mm.example.com/oauth/authorize?"
+            "client_id=mm-client&resource=https%3A%2F%2Fmcp.example.com%2Fmcp&parent_param=kept"
+        )
+
+    monkeypatch.setattr(OAuthProxy, "_build_upstream_authorize_url", build_parent_url)
+
+    upstream_url = auth._build_upstream_authorize_url("txn-id", {"resource": "https://mcp.example.com/mcp"})
+    query = parse_qs(urlparse(upstream_url).query)
+
+    assert query["client_id"] == ["mm-client"]
+    assert query["parent_param"] == ["kept"]
+    assert "resource" not in query
+
+
+@pytest.mark.asyncio
+async def test_mattermost_oauth_proxy_closes_mattermost_verifier() -> None:
+    """OAuth proxy owns the Mattermost verifier and closes it during server shutdown."""
+    from fastmcp.server.auth import AccessToken
+
+    from mcp_server_mattermost.auth import MattermostTokenVerifier
+    from mcp_server_mattermost.auth_oauth import MattermostOAuthProxy
+
+    class TrackingVerifier(MattermostTokenVerifier):
+        def __init__(self) -> None:
+            super().__init__()
+            self.closed = False
+
+        async def verify_token(self, token: str) -> AccessToken | None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+            await super().close()
+
+    verifier = TrackingVerifier()
+    auth = MattermostOAuthProxy(
+        upstream_authorization_endpoint="https://mm.example.com/oauth/authorize",
+        upstream_token_endpoint="https://mm.example.com/oauth/access_token",
+        upstream_client_id="mm-client",
+        upstream_client_secret="",
+        mattermost_verifier=verifier,
+        base_url="https://mcp.example.com",
+        token_endpoint_auth_method="none",
+        jwt_signing_key="signing-key-1234567890",
+    )
+
+    await auth.close()
+
+    assert verifier.closed is True

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -1,6 +1,7 @@
 """Tests for Mattermost OAuthProxy construction."""
 
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 from fastmcp.server.auth import OAuthProxy
 
@@ -92,7 +93,39 @@ def test_build_public_oauth_proxy_passes_explicit_signing_key() -> None:
         oauth_mcp_public_url="http://localhost:8000",
     )
 
-    with patch("mcp_server_mattermost.auth_oauth.OAuthProxy") as proxy_cls:
+    with patch("mcp_server_mattermost.auth_oauth.MattermostOAuthProxy") as proxy_cls:
         build_mattermost_oauth_proxy(settings)
 
     assert proxy_cls.call_args.kwargs["jwt_signing_key"] == "signing-key-1234567890"
+
+
+def test_mattermost_oauth_proxy_does_not_forward_resource_to_upstream_authorize() -> None:
+    """Mattermost rejects RFC8707 resource indicators on /oauth/authorize."""
+    from mcp_server_mattermost.auth_oauth import build_mattermost_oauth_proxy
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings(
+        url="https://mattermost.internal",
+        auth_mode="oauth_proxy",
+        oauth_client_type="public",
+        oauth_client_id="mm-client",
+        oauth_jwt_signing_key="signing-key-1234567890",
+        oauth_mcp_public_url="https://mcp.example.com/mattermost",
+        oauth_mattermost_public_url="https://mm.example.com",
+    )
+
+    auth = build_mattermost_oauth_proxy(settings)
+    upstream_url = auth._build_upstream_authorize_url(
+        "txn-id",
+        {
+            "scopes": [],
+            "resource": "https://mcp.example.com/mattermost/mcp",
+            "proxy_code_verifier": "proxy-verifier",
+        },
+    )
+
+    query = parse_qs(urlparse(upstream_url).query)
+
+    assert query["client_id"] == ["mm-client"]
+    assert query["redirect_uri"] == ["https://mcp.example.com/mattermost/oauth/callback/mm"]
+    assert "resource" not in query

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,3 +148,201 @@ class TestAllowHttpClientTokens:
             pytest.raises(ValidationError, match="MATTERMOST_TOKEN is required"),
         ):
             Settings()
+
+
+class TestAuthModeSettings:
+    def test_default_auth_mode_is_static_token(self) -> None:
+        from mcp_server_mattermost.config import AuthMode, Settings
+
+        with patch.dict(
+            os.environ,
+            {"MATTERMOST_URL": "http://mm.example.com", "MATTERMOST_TOKEN": "static-token"},
+            clear=True,
+        ):
+            settings = Settings()
+
+        assert settings.auth_mode is AuthMode.STATIC_TOKEN
+        assert settings.allow_http_client_tokens is False
+
+    def test_auth_mode_client_token_does_not_require_static_token(self) -> None:
+        from mcp_server_mattermost.config import AuthMode, Settings
+
+        with patch.dict(
+            os.environ,
+            {"MATTERMOST_URL": "http://mm.example.com", "MATTERMOST_AUTH_MODE": "client_token"},
+            clear=True,
+        ):
+            settings = Settings()
+
+        assert settings.auth_mode is AuthMode.CLIENT_TOKEN
+        assert settings.token is None
+
+    def test_legacy_allow_http_client_tokens_maps_to_client_token(self) -> None:
+        from mcp_server_mattermost.config import AuthMode, Settings
+
+        with patch.dict(
+            os.environ,
+            {"MATTERMOST_URL": "http://mm.example.com", "MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS": "true"},
+            clear=True,
+        ):
+            settings = Settings()
+
+        assert settings.auth_mode is AuthMode.CLIENT_TOKEN
+        assert settings.allow_http_client_tokens is True
+
+    def test_legacy_flag_conflicts_with_explicit_static_token_mode(self) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "MATTERMOST_URL": "http://mm.example.com",
+                    "MATTERMOST_TOKEN": "static-token",
+                    "MATTERMOST_AUTH_MODE": "static_token",
+                    "MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS": "true",
+                },
+                clear=True,
+            ),
+            pytest.raises(ValidationError, match="MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS conflicts"),
+        ):
+            Settings()
+
+    def test_static_token_requires_token(self) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        with (
+            patch.dict(
+                os.environ,
+                {"MATTERMOST_URL": "http://mm.example.com", "MATTERMOST_AUTH_MODE": "static_token"},
+                clear=True,
+            ),
+            pytest.raises(ValidationError, match="MATTERMOST_TOKEN is required when MATTERMOST_AUTH_MODE=static_token"),
+        ):
+            Settings()
+
+    def test_oauth_proxy_public_minimal_valid_settings(self) -> None:
+        from mcp_server_mattermost.config import AuthMode, OAuthClientType, Settings
+
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_URL": "http://mattermost.internal",
+                "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+                "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+                "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+                "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+            },
+            clear=True,
+        ):
+            settings = Settings()
+
+        assert settings.auth_mode is AuthMode.OAUTH_PROXY
+        assert settings.oauth_client_type is OAuthClientType.PUBLIC
+        assert settings.oauth_client_id == "mm-oauth-client"
+        assert settings.oauth_mcp_public_url == "http://localhost:8000"
+        assert settings.oauth_callback_path == "/oauth/callback/mm"
+        assert settings.oauth_allowed_redirect_uris == ["http://localhost:*", "http://127.0.0.1:*"]
+
+    def test_oauth_proxy_requires_client_id(self) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "MATTERMOST_URL": "http://mattermost.internal",
+                    "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                    "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+                    "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+                    "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                },
+                clear=True,
+            ),
+            pytest.raises(ValidationError, match="MATTERMOST_OAUTH_CLIENT_ID is required"),
+        ):
+            Settings()
+
+    def test_oauth_proxy_public_requires_jwt_signing_key(self) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "MATTERMOST_URL": "http://mattermost.internal",
+                    "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                    "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+                    "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+                    "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                },
+                clear=True,
+            ),
+            pytest.raises(ValidationError, match="MATTERMOST_OAUTH_JWT_SIGNING_KEY is required for public"),
+        ):
+            Settings()
+
+    def test_oauth_proxy_confidential_requires_secret(self) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "MATTERMOST_URL": "http://mattermost.internal",
+                    "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                    "MATTERMOST_OAUTH_CLIENT_TYPE": "confidential",
+                    "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+                    "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                },
+                clear=True,
+            ),
+            pytest.raises(ValidationError, match="MATTERMOST_OAUTH_CLIENT_SECRET is required"),
+        ):
+            Settings()
+
+    def test_oauth_proxy_confidential_valid_settings(self) -> None:
+        from mcp_server_mattermost.config import AuthMode, OAuthClientType, Settings
+
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_URL": "http://mattermost.internal",
+                "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                "MATTERMOST_OAUTH_CLIENT_TYPE": "confidential",
+                "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+                "MATTERMOST_OAUTH_CLIENT_SECRET": "mm-secret",
+                "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "https://mcp.example.com",
+                "MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL": "https://mattermost.example.com",
+            },
+            clear=True,
+        ):
+            settings = Settings()
+
+        assert settings.auth_mode is AuthMode.OAUTH_PROXY
+        assert settings.oauth_client_type is OAuthClientType.CONFIDENTIAL
+        assert settings.oauth_client_secret == "mm-secret"
+        assert settings.oauth_mcp_public_url == "https://mcp.example.com"
+        assert settings.oauth_mattermost_public_url == "https://mattermost.example.com"
+
+    def test_oauth_proxy_callback_path_must_start_with_slash(self) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "MATTERMOST_URL": "http://mattermost.internal",
+                    "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                    "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+                    "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+                    "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+                    "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                    "MATTERMOST_OAUTH_CALLBACK_PATH": "oauth/callback/mm",
+                },
+                clear=True,
+            ),
+            pytest.raises(ValidationError, match="MATTERMOST_OAUTH_CALLBACK_PATH must start with '/'"),
+        ):
+            Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -233,6 +233,7 @@ class TestAuthModeSettings:
                 "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
                 "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
                 "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                "MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL": "https://mattermost.example.com",
             },
             clear=True,
         ):
@@ -242,8 +243,83 @@ class TestAuthModeSettings:
         assert settings.oauth_client_type is OAuthClientType.PUBLIC
         assert settings.oauth_client_id == "mm-oauth-client"
         assert settings.oauth_mcp_public_url == "http://localhost:8000"
+        assert settings.oauth_mattermost_public_url == "https://mattermost.example.com"
         assert settings.oauth_callback_path == "/oauth/callback/mm"
         assert settings.oauth_allowed_redirect_uris == ["http://localhost:*", "http://127.0.0.1:*"]
+
+    @pytest.mark.parametrize(
+        ("oauth_mcp_public_url", "expectation"),
+        [
+            ("https://mcp.example.com", "valid"),
+            ("http://localhost:8000", "valid"),
+            ("http://127.0.0.1:8000", "valid"),
+            ("http://[::1]:8000", "valid"),
+            ("http://mcp.example.com", "invalid"),
+            ("http://localhost.evil.com:8000", "invalid"),
+        ],
+    )
+    def test_oauth_proxy_mcp_public_url_must_use_https_unless_localhost(
+        self, oauth_mcp_public_url: str, expectation: str
+    ) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        env = {
+            "MATTERMOST_URL": "http://mattermost.internal",
+            "MATTERMOST_AUTH_MODE": "oauth_proxy",
+            "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+            "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+            "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+            "MATTERMOST_OAUTH_MCP_PUBLIC_URL": oauth_mcp_public_url,
+            "MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL": "https://mattermost.example.com",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            if expectation == "valid":
+                settings = Settings()
+                assert settings.oauth_mcp_public_url == oauth_mcp_public_url
+            else:
+                with pytest.raises(ValidationError, match="MATTERMOST_OAUTH_MCP_PUBLIC_URL must use HTTPS"):
+                    Settings()
+
+    @pytest.mark.parametrize(
+        ("mattermost_url", "oauth_mattermost_public_url", "expectation"),
+        [
+            ("http://mattermost.internal", "https://mattermost.example.com", "valid"),
+            ("http://mattermost.internal", "http://localhost:8065", "valid"),
+            ("https://mattermost.example.com", None, "valid"),
+            ("http://mattermost.internal", None, "invalid"),
+            ("http://mattermost.example.com", None, "invalid"),
+            ("http://mattermost.internal", "http://localhost.evil.com", "invalid"),
+        ],
+    )
+    def test_oauth_proxy_browser_facing_mattermost_url_must_use_https_unless_localhost(
+        self,
+        mattermost_url: str,
+        oauth_mattermost_public_url: str | None,
+        expectation: str,
+    ) -> None:
+        from mcp_server_mattermost.config import Settings
+
+        env = {
+            "MATTERMOST_URL": mattermost_url,
+            "MATTERMOST_AUTH_MODE": "oauth_proxy",
+            "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+            "MATTERMOST_OAUTH_CLIENT_ID": "mm-oauth-client",
+            "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+            "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+        }
+        if oauth_mattermost_public_url is not None:
+            env["MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL"] = oauth_mattermost_public_url
+
+        with patch.dict(os.environ, env, clear=True):
+            if expectation == "valid":
+                settings = Settings()
+                assert (settings.oauth_mattermost_public_url or settings.url).startswith(
+                    ("https://", "http://localhost")
+                )
+            else:
+                with pytest.raises(ValidationError, match="Browser-facing Mattermost URL must use HTTPS"):
+                    Settings()
 
     def test_oauth_proxy_requires_client_id(self) -> None:
         from mcp_server_mattermost.config import Settings

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -88,6 +88,7 @@ class TestGetClient:
         monkeypatch.setenv("MATTERMOST_OAUTH_CLIENT_ID", "mm-client")
         monkeypatch.setenv("MATTERMOST_OAUTH_JWT_SIGNING_KEY", "signing-key-1234567890")
         monkeypatch.setenv("MATTERMOST_OAUTH_MCP_PUBLIC_URL", "http://localhost:8000")
+        monkeypatch.setenv("MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL", "https://mattermost.example.com")
 
         mock_token = AccessToken(
             token="fastmcp-jwt",

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -7,20 +7,19 @@ import pytest
 
 class TestGetClient:
     @pytest.mark.asyncio
-    async def test_uses_settings_token_without_auth_context(self, mock_settings: None) -> None:
-        """Without auth context (STDIO), _token_override is None — settings.token used."""
+    async def test_static_token_uses_settings_token_without_override(self, mock_settings: None) -> None:
+        """static_token mode lets MattermostClient use settings.token."""
         from mcp_server_mattermost.client import MattermostClient
         from mcp_server_mattermost.deps import get_client
 
-        # get_access_token() returns None outside HTTP context
         with patch("mcp_server_mattermost.deps.get_access_token", return_value=None):
             async with get_client() as client:
                 assert isinstance(client, MattermostClient)
                 assert client._token_override is None
 
     @pytest.mark.asyncio
-    async def test_uses_access_token_claims_when_present(self, mock_settings_allow_http: None) -> None:
-        """With allow_http_client_tokens and AccessToken, uses mattermost_token from claims."""
+    async def test_client_token_uses_access_token_claims(self, mock_settings_allow_http: None) -> None:
+        """client_token mode uses mattermost_token from auth context."""
         from fastmcp.server.auth import AccessToken
 
         from mcp_server_mattermost.client import MattermostClient
@@ -39,44 +38,25 @@ class TestGetClient:
                 assert client._token_override == "from-mattermost-token"
 
     @pytest.mark.asyncio
-    async def test_no_override_when_allow_http_disabled(self, mock_settings: None) -> None:
-        """When allow_http_client_tokens=False, get_access_token() is not called."""
-        from fastmcp.server.auth import AccessToken
-
-        from mcp_server_mattermost.client import MattermostClient
+    async def test_client_token_missing_access_token_raises(self, mock_settings_allow_http: None) -> None:
+        """client_token mode never falls back to a static token."""
         from mcp_server_mattermost.deps import get_client
+        from mcp_server_mattermost.exceptions import AuthenticationError
 
-        mock_token = AccessToken(
-            token="raw-bearer",
-            client_id="user123",
-            scopes=[],
-            claims={"mattermost_token": "should-not-be-used"},
-        )
-
-        # Even if access token is present, it should be ignored when flag is False
-        with patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token):
-            async with get_client() as client:
-                assert isinstance(client, MattermostClient)
-                assert client._token_override is None
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=None),
+            pytest.raises(AuthenticationError, match="Mattermost token is required"),
+        ):
+            async with get_client():
+                pass
 
     @pytest.mark.asyncio
-    async def test_no_token_override_when_access_token_missing(self, mock_settings_allow_http: None) -> None:
-        """When allow_http_client_tokens=True but no AccessToken in context, token_override is None."""
-        from mcp_server_mattermost.client import MattermostClient
-        from mcp_server_mattermost.deps import get_client
-
-        with patch("mcp_server_mattermost.deps.get_access_token", return_value=None):
-            async with get_client() as client:
-                assert isinstance(client, MattermostClient)
-                assert client._token_override is None
-
-    @pytest.mark.asyncio
-    async def test_no_override_when_claims_missing_mattermost_token(self, mock_settings_allow_http: None) -> None:
-        """When allow_http_client_tokens=True but claims lack mattermost_token key, token_override is None."""
+    async def test_client_token_missing_mattermost_claim_raises(self, mock_settings_allow_http: None) -> None:
+        """client_token mode requires mattermost_token claim."""
         from fastmcp.server.auth import AccessToken
 
-        from mcp_server_mattermost.client import MattermostClient
         from mcp_server_mattermost.deps import get_client
+        from mcp_server_mattermost.exceptions import AuthenticationError
 
         mock_token = AccessToken(
             token="raw-bearer",
@@ -85,7 +65,40 @@ class TestGetClient:
             claims={"some_other_claim": "value"},
         )
 
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token),
+            pytest.raises(AuthenticationError, match="Mattermost token is required"),
+        ):
+            async with get_client():
+                pass
+
+    @pytest.mark.asyncio
+    async def test_oauth_proxy_uses_access_token_claims(self, monkeypatch) -> None:
+        """oauth_proxy mode uses mattermost_token from FastMCP OAuthProxy auth context."""
+        from fastmcp.server.auth import AccessToken
+
+        from mcp_server_mattermost.client import MattermostClient
+        from mcp_server_mattermost.config import get_settings
+        from mcp_server_mattermost.deps import get_client
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "http://mattermost.internal")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "oauth_proxy")
+        monkeypatch.setenv("MATTERMOST_OAUTH_CLIENT_TYPE", "public")
+        monkeypatch.setenv("MATTERMOST_OAUTH_CLIENT_ID", "mm-client")
+        monkeypatch.setenv("MATTERMOST_OAUTH_JWT_SIGNING_KEY", "signing-key-1234567890")
+        monkeypatch.setenv("MATTERMOST_OAUTH_MCP_PUBLIC_URL", "http://localhost:8000")
+
+        mock_token = AccessToken(
+            token="fastmcp-jwt",
+            client_id="user123",
+            scopes=[],
+            claims={"mattermost_token": "from-oauth-proxy"},
+        )
+
         with patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token):
             async with get_client() as client:
                 assert isinstance(client, MattermostClient)
-                assert client._token_override is None
+                assert client._token_override == "from-oauth-proxy"
+
+        get_settings.cache_clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -66,10 +66,10 @@ class TestServerIntegration:
 
 
 class TestMcpAuth:
-    """Tests for conditional MattermostTokenVerifier auth on the FastMCP instance."""
+    """Tests for conditional auth provider on the FastMCP instance."""
 
-    def test_create_mcp_no_auth(self, clean_env: None) -> None:
-        """Without allow_http_client_tokens, _create_mcp() returns instance with auth=None."""
+    def test_create_mcp_static_token_no_auth(self, clean_env: None) -> None:
+        """static_token mode returns instance with auth=None."""
         import os
         from unittest.mock import patch
 
@@ -78,7 +78,7 @@ class TestMcpAuth:
             {
                 "MATTERMOST_URL": "http://mm.example.com",
                 "MATTERMOST_TOKEN": "test-token",
-                "MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS": "false",
+                "MATTERMOST_AUTH_MODE": "static_token",
             },
         ):
             from mcp_server_mattermost.config import get_settings
@@ -90,8 +90,28 @@ class TestMcpAuth:
             assert instance.auth is None
             get_settings.cache_clear()
 
-    def test_create_mcp_with_auth(self, clean_env: None) -> None:
-        """With allow_http_client_tokens=True, _create_mcp() attaches MattermostTokenVerifier."""
+    def test_create_mcp_client_token_auth(self, clean_env: None) -> None:
+        """client_token mode attaches MattermostTokenVerifier."""
+        import os
+        from unittest.mock import patch
+
+        from mcp_server_mattermost.auth import MattermostTokenVerifier
+
+        with patch.dict(
+            os.environ,
+            {"MATTERMOST_URL": "http://mm.example.com", "MATTERMOST_AUTH_MODE": "client_token"},
+        ):
+            from mcp_server_mattermost.config import get_settings
+
+            get_settings.cache_clear()
+            from mcp_server_mattermost.server import _create_mcp
+
+            instance = _create_mcp()
+            assert isinstance(instance.auth, MattermostTokenVerifier)
+            get_settings.cache_clear()
+
+    def test_create_mcp_legacy_allow_http_client_tokens_auth(self, clean_env: None) -> None:
+        """Legacy allow_http_client_tokens flag still attaches MattermostTokenVerifier."""
         import os
         from unittest.mock import patch
 
@@ -111,8 +131,8 @@ class TestMcpAuth:
             get_settings.cache_clear()
 
     @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "t", "y", "TRUE", "On", "YES"])
-    def test_create_mcp_with_auth_truthy_values(self, clean_env: None, value: str) -> None:
-        """All pydantic-compatible truthy values enable auth."""
+    def test_create_mcp_legacy_truthy_values(self, clean_env: None, value: str) -> None:
+        """All pydantic-compatible legacy truthy values enable auth."""
         import os
         from unittest.mock import patch
 
@@ -128,4 +148,32 @@ class TestMcpAuth:
 
             instance = _create_mcp()
             assert isinstance(instance.auth, MattermostTokenVerifier), f"Expected auth for value={value!r}"
+            get_settings.cache_clear()
+
+    def test_create_mcp_oauth_proxy_auth(self, clean_env: None) -> None:
+        """oauth_proxy mode attaches OAuthProxy."""
+        import os
+        from unittest.mock import patch
+
+        from fastmcp.server.auth import OAuthProxy
+
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_URL": "http://mattermost.internal",
+                "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+                "MATTERMOST_OAUTH_CLIENT_ID": "mm-client",
+                "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+                "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                "MATTERMOST_OAUTH_REQUIRE_CONSENT": "false",
+            },
+        ):
+            from mcp_server_mattermost.config import get_settings
+
+            get_settings.cache_clear()
+            from mcp_server_mattermost.server import _create_mcp
+
+            instance = _create_mcp()
+            assert isinstance(instance.auth, OAuthProxy)
             get_settings.cache_clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,6 +166,7 @@ class TestMcpAuth:
                 "MATTERMOST_OAUTH_CLIENT_ID": "mm-client",
                 "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
                 "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                "MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL": "https://mattermost.example.com",
                 "MATTERMOST_OAUTH_REQUIRE_CONSENT": "false",
             },
         ):

--- a/tests/test_token_flow.py
+++ b/tests/test_token_flow.py
@@ -148,3 +148,4 @@ class TestOAuthProxyDiscovery:
         assert authorization_metadata["authorization_endpoint"] == "http://localhost:8000/authorize"
         assert authorization_metadata["registration_endpoint"] == "http://localhost:8000/register"
         assert authorization_metadata["token_endpoint"] == "http://localhost:8000/token"
+        assert authorization_metadata.get("client_id_metadata_document_supported") is not True

--- a/tests/test_token_flow.py
+++ b/tests/test_token_flow.py
@@ -30,7 +30,6 @@ class TestClientTokenFlow:
             -> User(id="user123")
         """
         from mcp_server_mattermost.config import get_settings
-        from mcp_server_mattermost.server import _create_mcp
 
         mm_url = "http://mattermost.example.com"
 
@@ -43,6 +42,7 @@ class TestClientTokenFlow:
             clear=True,
         ):
             get_settings.cache_clear()
+            from mcp_server_mattermost.server import _create_mcp
 
             mcp = _create_mcp()
             asgi_app = mcp.http_app(transport="streamable-http")
@@ -99,3 +99,52 @@ class TestClientTokenFlow:
         # FastMCP 3 call_tool returns a ToolResult; content[0].text is JSON-serialized.
         data = json.loads(result.content[0].text)
         assert data["id"] == "user123"
+
+
+class TestOAuthProxyDiscovery:
+    def test_oauth_proxy_mcp_endpoint_returns_resource_metadata_challenge(self) -> None:
+        """oauth_proxy mode exposes FastMCP OAuth metadata and protects /mcp."""
+        import os
+        from unittest.mock import patch
+
+        from starlette.testclient import TestClient
+
+        from mcp_server_mattermost.config import get_settings
+
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_URL": "http://mattermost.internal",
+                "MATTERMOST_AUTH_MODE": "oauth_proxy",
+                "MATTERMOST_OAUTH_CLIENT_TYPE": "public",
+                "MATTERMOST_OAUTH_CLIENT_ID": "mm-client",
+                "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
+                "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                "MATTERMOST_OAUTH_REQUIRE_CONSENT": "false",
+            },
+            clear=True,
+        ):
+            get_settings.cache_clear()
+            from mcp_server_mattermost.server import _create_mcp
+
+            app = _create_mcp().http_app(transport="streamable-http")
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.get("/mcp")
+                metadata_response = client.get("/.well-known/oauth-protected-resource/mcp")
+                as_response = client.get("/.well-known/oauth-authorization-server")
+            get_settings.cache_clear()
+
+        assert response.status_code == 401
+        assert (
+            'resource_metadata="http://localhost:8000/.well-known/oauth-protected-resource/mcp"'
+            in response.headers["www-authenticate"]
+        )
+        assert metadata_response.status_code == 200
+        metadata = metadata_response.json()
+        assert metadata["resource"] == "http://localhost:8000/mcp"
+        assert metadata["authorization_servers"] == ["http://localhost:8000/"]
+        assert as_response.status_code == 200
+        authorization_metadata = as_response.json()
+        assert authorization_metadata["authorization_endpoint"] == "http://localhost:8000/authorize"
+        assert authorization_metadata["registration_endpoint"] == "http://localhost:8000/register"
+        assert authorization_metadata["token_endpoint"] == "http://localhost:8000/token"

--- a/tests/test_token_flow.py
+++ b/tests/test_token_flow.py
@@ -120,6 +120,7 @@ class TestOAuthProxyDiscovery:
                 "MATTERMOST_OAUTH_CLIENT_ID": "mm-client",
                 "MATTERMOST_OAUTH_JWT_SIGNING_KEY": "signing-key-1234567890",
                 "MATTERMOST_OAUTH_MCP_PUBLIC_URL": "http://localhost:8000",
+                "MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL": "https://mattermost.example.com",
                 "MATTERMOST_OAUTH_REQUIRE_CONSENT": "false",
             },
             clear=True,


### PR DESCRIPTION
## Summary
- add MATTERMOST_AUTH_MODE=oauth_proxy using FastMCP OAuthProxy with Mattermost OAuth Applications
- support confidential and public Mattermost OAuth App modes while preserving static_token and client_token flows
- force MCP clients through Dynamic Client Registration so Claude Code loopback callbacks work reliably
- document Mattermost OAuth App setup, Docker HTTP deployment, and Claude Code connection flow

## Test Plan
- PYTHONPATH=src uv run pytest tests -q --ignore=tests/integration
- PYTHONPATH=src uv run pytest tests/test_auth_oauth.py tests/test_token_flow.py -q
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run mypy src
- uv run --extra docs mkdocs build --strict

## Notes
- Register the MCP server as a Mattermost OAuth 2.0 Application, not as a Keycloak client.
- The Mattermost OAuth callback remains fixed at /oauth/callback/mm; MCP client callbacks are handled by FastMCP DCR.