### PR TITLE
feat(messages): unread/since modes for get_channel_messages, add mark_channel_viewed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Mattermost rejects `limit_after=0` with HTTP 400; the previous `ge=0` bound
   surfaced an unclear server error).
 - Rewrote `get_channel_messages` and `mark_channel_viewed` docstrings to be
-  self-contained for agent consumption: mode-selection guidance up front,
-  inline bot-loop pattern (no external references), and explicit notes on
-  tombstones, system posts, cascade `update_at`, the `last_viewed_at == 0`
-  bootstrap quirk, and admin no-op on non-member channels. Corrected the
-  description of `last_viewed_at` advancement (set to the channel's current
-  `last_post_at`, not wall-clock `now()`).
+  self-contained and compact: intent → mode mapping up front, footgun-only
+  notes (`last_viewed_at == 0` bootstrap quirk, `since`-mode tombstones,
+  `truncated` semantics), implementation detail moved to Field descriptions
+  to keep agent context budget small.
 
 ## [0.4.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   response cap (`1000` for `?since=`, `limit_before + limit_after` for `/posts/unread`,
   `per_page` for default pagination).
 - `docs/examples.md` — restored "Morning Catch-Up" example, now end-to-end with the new
-  unread-window flow.
+  unread-window flow, and added a "Bot Monitor Loop" recipe with two patterns
+  (simple `unread_only` + `mark_channel_viewed`, and at-least-once `since` + watermark).
 - `list_my_channels` accepts an `only_unread` filter to return only channels
   with unread messages.
 - `mark_channel_viewed(channel_id)` — new tool that marks a channel as viewed
@@ -32,6 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threads are counted, matching the channel badge when Collapsed Reply Threads
   is off; `unread_msg_count_root` / `mention_count_root` count only root posts,
   matching the badge when Collapsed Reply Threads is on.
+- `get_channel_messages`: tightened `limit_after` validation to `1-200`
+  (Mattermost rejects `limit_after=0` with HTTP 400; the previous `ge=0` bound
+  surfaced an unclear server error).
+- Clarified docstrings for `get_channel_messages` and `mark_channel_viewed`:
+  tombstones / system posts / cascade `update_at` behavior; corrected the
+  description of `last_viewed_at` advancement (set to the channel's current
+  `last_post_at`, not wall-clock `now()`); pointed bot-loop authors at the new
+  recipe in `docs/examples.md`.
 
 ## [0.4.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unread-window flow.
 - `list_my_channels` accepts an `only_unread` filter to return only channels
   with unread messages.
+- `mark_channel_viewed(channel_id)` — new tool that marks a channel as viewed
+  for the authenticated user. Resets the channel-member unread counters and
+  advances `last_viewed_at`. Documented usage: explicit user intent or a
+  bot-monitoring loop that owns the read state.
 
 ### Changed
 - `list_my_channels` now returns four unread counters for each channel:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `get_channel_messages` now supports two new mutually-exclusive modes:
+  - `unread_only=True` — fetches the user's unread window via Mattermost's
+    `/users/me/channels/{id}/posts/unread` endpoint, with `limit_before` /
+    `limit_after` bounds and a `collapsed_threads` flag for CRT-on users.
+  - `since=<unix_ms>` — fetches posts modified after a timestamp via `?since=`,
+    suitable for incremental sync.
+- `PostList` now exposes `truncated: bool` — `True` when the response hit Mattermost's
+  response cap (`1000` for `?since=`, `limit_before + limit_after` for `/posts/unread`,
+  `per_page` for default pagination).
+- `docs/examples.md` — restored "Morning Catch-Up" example, now end-to-end with the new
+  unread-window flow.
 - `list_my_channels` accepts an `only_unread` filter to return only channels
   with unread messages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_channel_messages`: tightened `limit_after` validation to `1-200`
   (Mattermost rejects `limit_after=0` with HTTP 400; the previous `ge=0` bound
   surfaced an unclear server error).
-- Clarified docstrings for `get_channel_messages` and `mark_channel_viewed`:
-  tombstones / system posts / cascade `update_at` behavior; corrected the
+- Rewrote `get_channel_messages` and `mark_channel_viewed` docstrings to be
+  self-contained for agent consumption: mode-selection guidance up front,
+  inline bot-loop pattern (no external references), and explicit notes on
+  tombstones, system posts, cascade `update_at`, the `last_viewed_at == 0`
+  bootstrap quirk, and admin no-op on non-member channels. Corrected the
   description of `last_viewed_at` advancement (set to the channel's current
-  `last_post_at`, not wall-clock `now()`); pointed bot-loop authors at the new
-  recipe in `docs/examples.md`.
+  `last_post_at`, not wall-clock `now()`).
 
 ## [0.4.0] - 2026-03-24
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -173,6 +173,92 @@ digest stays in your conversation with the AI.
 
 ---
 
+## Bot Monitor Loop
+
+> "Watch a set of channels and react to new messages on a schedule, without re-processing what's already handled."
+
+A bot account polls Mattermost on an interval and processes new posts. Two patterns,
+pick the one that matches your reliability requirements.
+
+### Pattern A — simple (recommended for most bots)
+
+Use `unread_only` to fetch new posts, then `mark_channel_viewed` to advance the read
+marker. Mattermost handles the bookkeeping; the bot stays stateless.
+
+**Tools used:**
+
+1. `list_my_channels(only_unread=True)` — channels with new messages.
+2. `get_channel_messages(channel_id, unread_only=True)` — the unread window.
+3. `mark_channel_viewed(channel_id)` — clear unread after processing.
+
+**Loop:**
+
+```python
+for ch in list_my_channels(team_id, only_unread=True):
+    if ch.last_viewed_at == 0:
+        mark_channel_viewed(ch.id)        # one-time bootstrap on a fresh channel
+        continue
+    posts = get_channel_messages(ch.id, unread_only=True, limit_after=200)
+    handle(posts)
+    mark_channel_viewed(ch.id)
+```
+
+**Trade-offs:**
+
+- Best fit for a dedicated bot account (no human shares the unread badge).
+- A post that arrives between `get_channel_messages` and `mark_channel_viewed`
+  is marked as viewed without being handled. For most bots this race window
+  is too small to matter; on very busy channels or when no message can be
+  lost, use Pattern B.
+
+### Pattern B — at-least-once (when losses are unacceptable)
+
+Use `since` with a watermark stored outside Mattermost. The bot processes everything
+modified after the watermark, deduplicates by `post.id`, and advances the watermark
+only after a successful handler.
+
+**Tools used:**
+
+1. `list_my_channels` — discover channels.
+2. `get_channel_messages(channel_id, since=watermark)` — everything new or edited
+   since the last successful run.
+
+**Loop:**
+
+```python
+# Persistent across restarts — file, Redis, DB.
+watermarks: dict[ChannelId, int]
+processed: set[PostId]
+
+for ch in list_my_channels(team_id):
+    last_seen = watermarks.get(ch.id, 0)
+    result = get_channel_messages(ch.id, since=last_seen)
+    for post in result.posts.values():
+        if post.id in processed:
+            continue
+        if post.delete_at != 0:
+            continue                       # skip tombstones from deleted posts
+        handle(post)
+        processed.add(post.id)
+    if result.posts:
+        watermarks[ch.id] = max(p.update_at for p in result.posts.values())
+```
+
+**When to choose this:**
+
+- A missed message is a real problem (alert handling, audit trail, etc.).
+- The bot shares an account with a human — Pattern A would clear their unread badge.
+- The bot needs to see edits and deletions of older posts, not just new ones.
+
+**Things to know:**
+
+- `since` returns up to 1000 posts; on `result.truncated == True` poll more often
+  or step the watermark forward in smaller windows.
+- System posts (`type` starts with `"system_"`) and edits of older posts come back
+  too — filter or process them based on what the bot is for.
+
+---
+
 ## Daily Channel Digest
 
 > "Catch me up on #backend — what happened while I was away?"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -148,6 +148,31 @@ structured release notes — grouped by category, each with its own color:
 
 ---
 
+## Morning Catch-Up
+
+> "What did I miss? Give me a rundown of my unread channels."
+
+The AI lists every channel with unread messages, then for each one fetches the precise
+unread window — not just the last N posts. It uses `last_viewed_at` as the read marker
+and `unread_only=true` for deterministic ordering:
+
+**Tools used:**
+
+1. `list_my_channels` — `only_unread=true` returns only channels with unread messages,
+   each enriched with `unread_msg_count`, `mention_count`, `unread_msg_count_root`,
+   `mention_count_root`, and `last_viewed_at`.
+2. `get_channel_messages` — `unread_only=true` fetches the unread window for each
+   channel via Mattermost's `/posts/unread` endpoint. The AI passes `limit_after=200`
+   to retrieve up to 200 unread posts per channel; if `truncated` comes back True, more
+   exists beyond the window.
+
+The AI prioritizes channels by `mention_count` first, then by total unreads. For each
+channel it groups the returned posts by `root_id` to surface threads alongside their root
+context posts (which Mattermost auto-includes). Nothing is posted to Mattermost; the
+digest stays in your conversation with the AI.
+
+---
+
 ## Daily Channel Digest
 
 > "Catch me up on #backend — what happened while I was away?"

--- a/docs/tools/channels.md
+++ b/docs/tools/channels.md
@@ -287,6 +287,57 @@ None
 
 ---
 
+## mark_channel_viewed
+
+Mark a channel as viewed for the authenticated user.
+
+Resets the channel-member unread counters (msg_count = total_msg_count,
+mention_count = 0) and advances `last_viewed_at` to the current server time.
+
+**When to use:**
+
+- The user explicitly asks to mark a channel as read.
+- A bot-monitoring loop where the agent owns the read state for the authenticated
+  account, after processing posts fetched via `get_channel_messages(unread_only=true)`.
+
+**Do not call** automatically after fetching unread posts. The user may still rely on
+the Mattermost UI unread badge as a "still need to handle" reminder outside of the AI
+session.
+
+### Example prompts
+
+- "Mark the engineering channel as read"
+- "I've processed everything in #releases — clear the unread badge"
+
+### Annotations
+
+| Hint | Value |
+|------|-------|
+| `readOnlyHint` | false |
+| `destructiveHint` | false |
+| `idempotentHint` | false |
+| `capability` | write |
+
+Not idempotent: each call advances `last_viewed_at` to the current server time, and any
+posts arriving between two consecutive calls are silently marked as viewed by the
+second call.
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `channel_id` | string | ✓ | — | Channel ID (26-character alphanumeric) |
+
+### Returns
+
+None.
+
+### Mattermost API
+
+[POST /api/v4/channels/members/{user_id}/view](https://api.mattermost.com/#tag/channels/operation/ViewChannel)
+
+---
+
 ## get_channel_members
 
 Get members of a channel.

--- a/docs/tools/messages.md
+++ b/docs/tools/messages.md
@@ -69,16 +69,27 @@ Post object with `id`, `channel_id`, `message`, `create_at`, `user_id`.
 
 ## get_channel_messages
 
-Get recent messages from a channel.
+Read messages from a channel — either the most recent batch, the user's unread window, or messages modified after a given timestamp.
 
-Returns messages in reverse chronological order (newest first).
-Use for reading channel conversation history.
-For searching messages by keywords across channels, use search_messages instead.
+Three mutually-exclusive modes:
+
+- **Default** — paginated reverse-chronological history. The default behaviour
+  for "show me the channel".
+- **`unread_only=True`** — the user's unread window via `/posts/unread`. Returns
+  up to `limit_after` unread posts plus `limit_before` context posts.
+  Deterministic ordering; edits of older posts do not appear.
+- **`since=<ms>`** — posts with `update_at > since`, ordered by `create_at`.
+  Includes edits of older posts. Intended for incremental sync where the
+  caller tracks its own watermark, not for direct human use.
+
+For keyword search across channels, use `search_messages`.
+To read a thread in full, use `get_thread`.
 
 ### Example prompts
 
 - "Show me the last 10 messages in #general"
-- "What's the recent conversation in engineering?"
+- "What's new in #engineering?"
+- "Catch me up on #releases — what did I miss?"
 - "Read the channel history"
 
 ### Annotations
@@ -93,17 +104,52 @@ For searching messages by keywords across channels, use search_messages instead.
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `channel_id` | string | ✓ | — | Channel ID |
-| `page` | integer | — | 0 | Page number (0-indexed) |
-| `per_page` | integer | — | 60 | Results per page (1-200) |
+| `channel_id` | string | ✓ | — | Channel ID (26-character alphanumeric) |
+| `unread_only` | boolean | — | false | Use the unread-window mode. Mutually exclusive with `since` and pagination. |
+| `since` | integer | — | — | Unix timestamp in milliseconds (≥ 10¹²). Returns posts with `update_at > since`. Mutually exclusive with `unread_only` and pagination. |
+| `page` | integer | — | 0 | Page number, 0-indexed. Default mode only. |
+| `per_page` | integer | — | 60 | Page size, 1–200. Default mode only. |
+| `limit_before` | integer | — | 0 | Context posts before the first unread, 0–200. `unread_only` mode only. |
+| `limit_after` | integer | — | 60 | Unread posts to return, 0–200. `unread_only` mode only. |
+| `collapsed_threads` | boolean | — | false | Set true if [CRT][crt-end-user] is enabled. Valid only with `unread_only` or `since`. Team default is CRT off. |
 
 ### Returns
 
-Object with `posts` (map of post objects) and `order` (array of post IDs).
+Object with:
+
+- `posts` — map of post objects keyed by post ID.
+- `order` — array of post IDs in reverse-chronological order.
+- `truncated` — boolean. True when the response hit the per-mode cap and more
+  posts likely exist beyond this batch (default: `len(order) >= per_page`;
+  `unread_only`: `>= limit_before + limit_after`; `since`: `>= 1000`, the
+  server hard-cap).
+
+### Behavior notes
+
+- **Collapsed Reply Threads (CRT)** changes how unread counts and thread
+  replies surface. With CRT off (team default), `unread_msg_count` from
+  `list_my_channels` and this tool's response in any mode both count thread
+  replies. With CRT on, pass `collapsed_threads=true` and fetch full threads
+  via `get_thread` when needed. See the [end-user overview][crt-end-user] for
+  what CRT does in the UI, and the [administrator guide][crt-admin] for how
+  it is enabled on a server.
+- `since` mode is the only one that surfaces edits of older posts. A post
+  with `create_at <= since AND update_at > since` is an edit; filter by
+  `create_at` if you only want new messages.
+- `since` mode is capped at 1000 posts server-side. When the cap is hit
+  (`truncated=true`), the returned posts are not guaranteed to be
+  consecutive — there can be gaps between them and posts not in the
+  response. Prefer `unread_only=true` for a deterministic windowed read.
+- For watermark-based sync, read `ChannelWithUnreads.last_viewed_at` from
+  `list_my_channels` and pass it as `since`.
+
+[crt-end-user]: https://docs.mattermost.com/end-user-guide/collaborate/organize-conversations.html
+[crt-admin]: https://support.mattermost.com/hc/en-us/articles/6880701948564-Administrator-s-guide-to-enabling-Collapsed-Reply-Threads
 
 ### Mattermost API
 
-[GET /api/v4/channels/{channel_id}/posts](https://api.mattermost.com/#tag/posts/operation/GetPostsForChannel)
+- [GET /api/v4/channels/{channel_id}/posts](https://api.mattermost.com/#tag/posts/operation/GetPostsForChannel) — default and `since` modes.
+- [GET /api/v4/users/{user_id}/channels/{channel_id}/posts/unread](https://api.mattermost.com/#tag/posts/operation/GetPostsAroundLastUnread) — `unread_only` mode.
 
 ---
 

--- a/docs/tools/messages.md
+++ b/docs/tools/messages.md
@@ -110,7 +110,7 @@ To read a thread in full, use `get_thread`.
 | `page` | integer | — | 0 | Page number, 0-indexed. Default mode only. |
 | `per_page` | integer | — | 60 | Page size, 1–200. Default mode only. |
 | `limit_before` | integer | — | 0 | Context posts before the first unread, 0–200. `unread_only` mode only. |
-| `limit_after` | integer | — | 60 | Unread posts to return, 0–200. `unread_only` mode only. |
+| `limit_after` | integer | — | 60 | Unread posts to return, 1–200. `unread_only` mode only. |
 | `collapsed_threads` | boolean | — | false | Set true if [CRT][crt-end-user] is enabled. Valid only with `unread_only` or `since`. Team default is CRT off. |
 
 ### Returns

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -705,6 +705,40 @@ class MattermostClient:
         )
         return result if isinstance(result, dict) else {}
 
+    async def get_posts_since(
+        self,
+        channel_id: str,
+        since: int,
+        *,
+        collapsed_threads: bool = False,
+    ) -> dict[str, Any]:
+        """Get posts in a channel modified after a given timestamp.
+
+        Uses ``GET /channels/{id}/posts?since=<ms>``. Filters by
+        ``Posts.UpdateAt > since``, so edits of older posts and threads with new replies
+        are included. Context root posts for new replies are auto-included in ``posts``
+        but NOT in ``order`` (server-side behavior).
+
+        Per Mattermost spec, ``since`` is mutually exclusive with ``page``/``per_page``;
+        this method does not accept them. Server hard-caps the response at 1000 posts
+        without a deterministic ORDER BY; check ``len(result['order'])`` to detect
+        truncation.
+
+        Args:
+            channel_id: Channel identifier.
+            since: Unix timestamp in milliseconds.
+            collapsed_threads: True if the user has CRT enabled — tells Mattermost to
+                return CRT-aware data (default False; team operates with CRT off).
+
+        Returns:
+            Dict with 'posts' (id->post) and 'order' (list of root post ids).
+        """
+        params: dict[str, Any] = {"since": since}
+        if collapsed_threads:
+            params["collapsedThreads"] = "true"
+        result = await self.get(f"/channels/{channel_id}/posts", params=params)
+        return result if isinstance(result, dict) else {}
+
     async def create_post(
         self,
         channel_id: str,

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -639,6 +639,23 @@ class MattermostClient:
         user_id = await self._get_current_user_id()
         await self.delete(f"/channels/{channel_id}/members/{user_id}")
 
+    async def view_channel(self, channel_id: str) -> None:
+        """Mark a channel as viewed for the authenticated user.
+
+        Calls ``POST /channels/members/me/view`` with ``{"channel_id": ...}`` in the
+        body. Mattermost resets the channel-member counters (``msg_count =
+        total_msg_count``, ``mention_count = 0``) and updates ``last_viewed_at`` to the
+        current server time.
+
+        Args:
+            channel_id: Channel to mark as viewed.
+        """
+        await self._request(
+            "POST",
+            "/channels/members/me/view",
+            json={"channel_id": channel_id},
+        )
+
     async def get_channel_members(
         self,
         channel_id: str,

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -739,6 +739,44 @@ class MattermostClient:
         result = await self.get(f"/channels/{channel_id}/posts", params=params)
         return result if isinstance(result, dict) else {}
 
+    async def get_channel_posts_unread(
+        self,
+        channel_id: str,
+        limit_before: int = 0,
+        limit_after: int = 60,
+        *,
+        collapsed_threads: bool = False,
+    ) -> dict[str, Any]:
+        """Get a window of unread posts around the authenticated user's read marker.
+
+        Uses ``GET /users/me/channels/{id}/posts/unread``. Returns a window around the
+        oldest unread post, sorted reverse-chronologically. Unlike ``?since=``, edits of
+        older read posts do not surface here — only what's actually unread plus optional
+        context posts before the read marker.
+
+        Args:
+            channel_id: Channel identifier.
+            limit_before: How many read posts to include as context before the first
+                unread (0..200, default 0).
+            limit_after: How many unread posts to return (0..200, default 60).
+            collapsed_threads: True if the user has CRT enabled (default False).
+
+        Returns:
+            Dict with 'posts' and 'order'. Response size is capped at
+            ``limit_before + limit_after``.
+        """
+        params: dict[str, Any] = {
+            "limit_before": limit_before,
+            "limit_after": limit_after,
+        }
+        if collapsed_threads:
+            params["collapsedThreads"] = "true"
+        result = await self.get(
+            f"/users/me/channels/{channel_id}/posts/unread",
+            params=params,
+        )
+        return result if isinstance(result, dict) else {}
+
     async def create_post(
         self,
         channel_id: str,

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -737,9 +737,10 @@ class MattermostClient:
         but NOT in ``order`` (server-side behavior).
 
         Per Mattermost spec, ``since`` is mutually exclusive with ``page``/``per_page``;
-        this method does not accept them. Server hard-caps the response at 1000 posts
-        without a deterministic ORDER BY; check ``len(result['order'])`` to detect
-        truncation.
+        this method does not accept them. Posts are ordered by ``create_at`` and the
+        server caps the response at 1000 posts; when the cap is hit, the returned
+        posts are not guaranteed to be consecutive (gaps are possible). Check
+        ``len(result['order'])`` to detect truncation.
 
         Args:
             channel_id: Channel identifier.

--- a/src/mcp_server_mattermost/models/post.py
+++ b/src/mcp_server_mattermost/models/post.py
@@ -29,13 +29,22 @@ class PostList(MattermostResponse):
     """Response from get_posts and search_posts endpoints.
 
     Posts are returned as a dict keyed by ID for fast lookup.
-    Use `order` to iterate in display order (newest first).
+    Use ``order`` to iterate in display order (newest first).
+
+    ``truncated`` is set by the tool layer when the underlying Mattermost endpoint
+    hit a response cap (e.g. 1000 for ``?since=``, ``limit_after`` for
+    ``/posts/unread``). When ``truncated`` is True, the response is incomplete —
+    more posts exist beyond this batch.
     """
 
     order: list[str] = Field(description="Post IDs in display order")
     posts: dict[str, Post] = Field(description="Map of post ID to Post object")
     next_post_id: str = Field(default="", description="Next post ID for pagination")
     prev_post_id: str = Field(default="", description="Previous post ID for pagination")
+    truncated: bool = Field(
+        default=False,
+        description="True when the response hit a Mattermost response cap — more posts exist beyond this batch",
+    )
 
 
 class Reaction(MattermostResponse):

--- a/src/mcp_server_mattermost/tools/channels.py
+++ b/src/mcp_server_mattermost/tools/channels.py
@@ -223,25 +223,41 @@ async def mark_channel_viewed(
 ) -> None:
     """Mark a channel as viewed for the authenticated user.
 
-    Resets unread counters (``msg_count = total_msg_count``, ``mention_count = 0``)
-    and sets ``last_viewed_at`` to the channel's current ``last_post_at``.
+    Resets the channel-member unread counters (``unread_msg_count`` and
+    ``mention_count`` go to 0) and sets ``last_viewed_at`` to the channel's
+    current ``last_post_at``. After this call, ``unread_msg_count`` from
+    ``list_my_channels`` returns 0 for the channel, and
+    ``get_channel_messages(unread_only=True)`` returns an empty window until
+    new posts arrive.
 
     WHEN TO USE:
-      - The user explicitly asks to clear an unread badge.
-      - A bot loop that owns the read state (see docs/examples.md
-        "Bot Monitor Loop" — Pattern A uses this after each fetch).
-      - One-shot bootstrap on a channel where ``last_viewed_at == 0``
-        so subsequent ``unread_only`` queries work.
+      - The user explicitly asks to clear an unread badge — "mark #releases
+        as read", "clear my unreads on this channel".
+      - A dedicated bot account that owns its read state, polling on an
+        interval. Typical loop:
+          1. ``list_my_channels(only_unread=True)`` → channels with new posts
+          2. ``get_channel_messages(channel_id, unread_only=True)`` → fetch
+          3. process the posts
+          4. ``mark_channel_viewed(channel_id)`` → advance the read marker
+        This is at-most-once delivery: a post arriving between steps 2 and 4
+        is silently marked as viewed without being handled. For at-least-once
+        delivery, use ``get_channel_messages(channel_id, since=<watermark>)``
+        with a watermark stored outside Mattermost, and skip this call.
+      - One-shot bootstrap on a channel where ``last_viewed_at == 0`` (never
+        viewed by this account) so subsequent ``unread_only`` queries work.
 
-    DO NOT call automatically when the account is shared with a human —
-    clearing the badge removes their "still need to handle" reminder.
+    DO NOT call automatically when the account is shared with a human — it
+    clears their unread badge in the Mattermost UI, removing a "still needs
+    attention" signal they may rely on outside this session.
 
-    Side-effects:
+    Behavior to know:
       - The new ``last_viewed_at`` equals the channel's current
         ``last_post_at`` at the time of the call, not wall-clock ``now()``.
-        On a quiet channel a repeated call is effectively a no-op.
-      - For admins on a non-member channel, the request returns success
-        but Mattermost silently ignores it (no membership is created).
+        On a channel with no new posts since the previous call, this is
+        effectively a no-op (idempotent).
+      - When the caller is not a member of the channel, an admin token
+        returns HTTP 200 but Mattermost silently ignores the request — no
+        membership is created and no counters reset.
     """
     await client.view_channel(channel_id=channel_id)
 

--- a/src/mcp_server_mattermost/tools/channels.py
+++ b/src/mcp_server_mattermost/tools/channels.py
@@ -221,43 +221,15 @@ async def mark_channel_viewed(
     channel_id: ChannelId,
     client: MattermostClient = Depends(get_client),  # noqa: B008
 ) -> None:
-    """Mark a channel as viewed for the authenticated user.
+    """Mark a channel as read for the authenticated user.
 
-    Resets the channel-member unread counters (``unread_msg_count`` and
-    ``mention_count`` go to 0) and sets ``last_viewed_at`` to the channel's
-    current ``last_post_at``. After this call, ``unread_msg_count`` from
-    ``list_my_channels`` returns 0 for the channel, and
-    ``get_channel_messages(unread_only=True)`` returns an empty window until
-    new posts arrive.
+    Clears unread counters and advances ``last_viewed_at``. Use when the user
+    asks to clear unreads, when a bot has processed
+    ``get_channel_messages(unread_only=True)`` and needs to advance read state
+    for the next poll, or as a one-shot bootstrap on a channel with
+    ``last_viewed_at == 0`` so ``unread_only`` queries return posts.
 
-    WHEN TO USE:
-      - The user explicitly asks to clear an unread badge — "mark #releases
-        as read", "clear my unreads on this channel".
-      - A dedicated bot account that owns its read state, polling on an
-        interval. Typical loop:
-          1. ``list_my_channels(only_unread=True)`` → channels with new posts
-          2. ``get_channel_messages(channel_id, unread_only=True)`` → fetch
-          3. process the posts
-          4. ``mark_channel_viewed(channel_id)`` → advance the read marker
-        This is at-most-once delivery: a post arriving between steps 2 and 4
-        is silently marked as viewed without being handled. For at-least-once
-        delivery, use ``get_channel_messages(channel_id, since=<watermark>)``
-        with a watermark stored outside Mattermost, and skip this call.
-      - One-shot bootstrap on a channel where ``last_viewed_at == 0`` (never
-        viewed by this account) so subsequent ``unread_only`` queries work.
-
-    DO NOT call automatically when the account is shared with a human — it
-    clears their unread badge in the Mattermost UI, removing a "still needs
-    attention" signal they may rely on outside this session.
-
-    Behavior to know:
-      - The new ``last_viewed_at`` equals the channel's current
-        ``last_post_at`` at the time of the call, not wall-clock ``now()``.
-        On a channel with no new posts since the previous call, this is
-        effectively a no-op (idempotent).
-      - When the caller is not a member of the channel, an admin token
-        returns HTTP 200 but Mattermost silently ignores the request — no
-        membership is created and no counters reset.
+    Do NOT call on accounts shared with humans — it clears their UI badge.
     """
     await client.view_channel(channel_id=channel_id)
 

--- a/src/mcp_server_mattermost/tools/channels.py
+++ b/src/mcp_server_mattermost/tools/channels.py
@@ -223,32 +223,25 @@ async def mark_channel_viewed(
 ) -> None:
     """Mark a channel as viewed for the authenticated user.
 
-    Resets the channel-member unread counters
-    (``msg_count = total_msg_count``, ``mention_count = 0``) and advances
-    ``last_viewed_at`` to the current server time.
+    Resets unread counters (``msg_count = total_msg_count``, ``mention_count = 0``)
+    and sets ``last_viewed_at`` to the channel's current ``last_post_at``.
 
     WHEN TO USE:
-      - The user explicitly asks to mark a channel as read
-        ("clear the unread badge on #releases").
-      - A bot-monitoring loop where THIS agent owns the read state for
-        the authenticated account: after processing posts from
-        ``get_channel_messages(unread_only=True)``, advance the marker so
-        the next poll only returns truly new posts.
+      - The user explicitly asks to clear an unread badge.
+      - A bot loop that owns the read state (see docs/examples.md
+        "Bot Monitor Loop" — Pattern A uses this after each fetch).
+      - One-shot bootstrap on a channel where ``last_viewed_at == 0``
+        so subsequent ``unread_only`` queries work.
 
-    DO NOT CALL automatically after fetching unread posts via
-    ``get_channel_messages(unread_only=True)``. Doing so destroys the
-    user's unread badge in the Mattermost UI, which they may still rely
-    on as a "still need to handle" reminder outside of this AI session.
+    DO NOT call automatically when the account is shared with a human —
+    clearing the badge removes their "still need to handle" reminder.
 
-    At-least-once delivery (bot loops): capture ``last_viewed_at`` from
-    ``list_my_channels`` BEFORE the unread fetch. On the next cycle, pass
-    that captured timestamp as ``get_channel_messages(since=...)`` instead
-    of relying on ``unread_only=True`` — this re-fetches anything written
-    in the race window between fetch and mark.
-
-    Not idempotent: each call advances ``last_viewed_at`` to a new ``now()``,
-    and any posts arriving between two consecutive calls are silently
-    marked as viewed by the second call.
+    Side-effects:
+      - The new ``last_viewed_at`` equals the channel's current
+        ``last_post_at`` at the time of the call, not wall-clock ``now()``.
+        On a quiet channel a repeated call is effectively a no-op.
+      - For admins on a non-member channel, the request returns success
+        but Mattermost silently ignores it (no membership is created).
     """
     await client.view_channel(channel_id=channel_id)
 

--- a/src/mcp_server_mattermost/tools/channels.py
+++ b/src/mcp_server_mattermost/tools/channels.py
@@ -213,6 +213,47 @@ async def leave_channel(
 
 
 @tool(
+    annotations={"destructiveHint": False},
+    tags={ToolTag.MATTERMOST, ToolTag.CHANNEL},
+    meta={"capability": Capability.WRITE},
+)
+async def mark_channel_viewed(
+    channel_id: ChannelId,
+    client: MattermostClient = Depends(get_client),  # noqa: B008
+) -> None:
+    """Mark a channel as viewed for the authenticated user.
+
+    Resets the channel-member unread counters
+    (``msg_count = total_msg_count``, ``mention_count = 0``) and advances
+    ``last_viewed_at`` to the current server time.
+
+    WHEN TO USE:
+      - The user explicitly asks to mark a channel as read
+        ("clear the unread badge on #releases").
+      - A bot-monitoring loop where THIS agent owns the read state for
+        the authenticated account: after processing posts from
+        ``get_channel_messages(unread_only=True)``, advance the marker so
+        the next poll only returns truly new posts.
+
+    DO NOT CALL automatically after fetching unread posts via
+    ``get_channel_messages(unread_only=True)``. Doing so destroys the
+    user's unread badge in the Mattermost UI, which they may still rely
+    on as a "still need to handle" reminder outside of this AI session.
+
+    At-least-once delivery (bot loops): capture ``last_viewed_at`` from
+    ``list_my_channels`` BEFORE the unread fetch. On the next cycle, pass
+    that captured timestamp as ``get_channel_messages(since=...)`` instead
+    of relying on ``unread_only=True`` — this re-fetches anything written
+    in the race window between fetch and mark.
+
+    Not idempotent: each call advances ``last_viewed_at`` to a new ``now()``,
+    and any posts arriving between two consecutive calls are silently
+    marked as viewed by the second call.
+    """
+    await client.view_channel(channel_id=channel_id)
+
+
+@tool(
     annotations={"readOnlyHint": True, "idempotentHint": True},
     tags={ToolTag.MATTERMOST, ToolTag.CHANNEL, ToolTag.USER},
     meta={"capability": Capability.READ},

--- a/src/mcp_server_mattermost/tools/channels.py
+++ b/src/mcp_server_mattermost/tools/channels.py
@@ -73,14 +73,23 @@ async def list_my_channels(
 ) -> list[ChannelWithUnreads]:
     """List channels you are a member of in a team.
 
-    Returns your channels with unread counters for the authenticated user. Two
-    counter pairs are provided: unread_msg_count / mention_count count thread
-    replies too (the channel badge with Collapsed Reply Threads off), while
-    unread_msg_count_root / mention_count_root count only root posts (the badge
-    with Collapsed Reply Threads on). Channels without a membership record
-    report 0 for all four counters.
-    Use channel_types to narrow results: ["O", "P"] for workspace channels
-    without DMs, or ["D"] for direct messages only.
+    Returns your channels with unread counters and the read marker for the authenticated
+    user. Two counter pairs are provided:
+
+    - ``unread_msg_count`` / ``mention_count`` count thread replies too (the channel
+      badge with Collapsed Reply Threads off — the team default).
+    - ``unread_msg_count_root`` / ``mention_count_root`` count only root posts (the
+      badge with Collapsed Reply Threads on).
+
+    ``last_viewed_at`` is the user's read marker for the channel. Pass it as
+    ``get_channel_messages(channel_id, since=last_viewed_at)`` for incremental sync, or
+    use ``get_channel_messages(channel_id, unread_only=True)`` for the unread window
+    (preferred — deterministic and edit-noise-free).
+
+    Channels without a membership record report 0 for all counters and ``last_viewed_at``.
+
+    Use channel_types to narrow results: ["O", "P"] for workspace channels without DMs,
+    or ["D"] for direct messages only.
     Use only_unread=True to get only channels with unread messages.
     For discovering public channels you haven't joined yet, use list_public_channels.
     """

--- a/src/mcp_server_mattermost/tools/messages.py
+++ b/src/mcp_server_mattermost/tools/messages.py
@@ -149,59 +149,26 @@ async def get_channel_messages(  # noqa: PLR0913
 
     Three mutually-exclusive modes. Pick by user intent:
 
-      - "Show me the last N messages" / "what's in this channel" → default
-        (page, per_page).
-      - "What did I miss" / "catch me up" → unread_only=True.
-      - "Sync everything modified since <ms>" → since=<unix_ms>.
+    - "Show last N" / "what's in this channel" → default (page, per_page).
+      Reverse-chronological. ``truncated=True`` ⇒ more posts exist; paginate.
 
-    Mode behavior:
+    - "What did I miss" → ``unread_only=True``. The user's unread window
+      anchored at ``last_viewed_at``, with ``limit_before`` context posts.
+      Quirk: on a never-viewed channel (``last_viewed_at == 0``) ``order``
+      is empty even when ``unread_msg_count > 0`` — call
+      ``mark_channel_viewed`` once to bootstrap.
 
-    - **Default** (page, per_page): the most recent posts in reverse-chronological
-      order. ``truncated=True`` when the page is full and more posts likely exist;
-      paginate with ``page+1``.
+    - "Sync everything since <ms>" → ``since=<unix_ms>``. Posts with
+      ``update_at > since``, including edits of older posts and tombstones
+      (``delete_at != 0``, empty ``message``). Server caps at 1000; on
+      ``truncated=True`` step the watermark forward in smaller windows.
 
-    - **unread_only=True** (with limit_before, limit_after): the user's unread
-      window, anchored at Mattermost's read marker ``last_viewed_at``. Returns up
-      to ``limit_after`` unread posts plus ``limit_before`` already-read posts as
-      context. Edits of older posts are NOT included. Deleted posts are excluded.
-      On a never-viewed channel (``last_viewed_at == 0``) ``order`` comes back
-      empty even when ``unread_msg_count > 0`` — call ``mark_channel_viewed`` once
-      after the channel has at least one post to bootstrap.
+    Returns ``{order, posts, truncated}``. ``posts`` may contain more entries
+    than ``order`` (root posts pulled in by thread replies). System posts
+    (``type`` starts with ``"system_"``) appear in ``unread_only``/``since``
+    responses but are NOT counted in ``unread_msg_count``.
 
-    - **since=<unix_ms>**: posts with ``update_at > since``, ordered by
-      ``create_at``. Use when the caller tracks its own watermark, or when edits
-      and deletes of older posts also matter. Includes:
-          * edits of older posts (``create_at <= since AND update_at > since``);
-          * tombstones for deletions (``delete_at != 0``, empty ``message``,
-            ``props.deleteBy`` set);
-          * cascade updates — a root post's ``update_at`` advances when any reply
-            in its thread is edited or deleted, even if the root itself didn't
-            change.
-      Filter by ``create_at > since`` for newly-created posts only; check
-      ``delete_at == 0`` for live messages only. The server caps the response at
-      1000 posts; when ``truncated=True`` the returned posts may not be
-      contiguous (gaps possible) — step ``since`` forward in smaller windows.
-
-    Returns an object with:
-      - ``order``: list of post IDs in reverse-chronological order;
-      - ``posts``: dict of post objects keyed by ID — may contain more entries
-        than ``order`` (e.g. root posts referenced by thread replies);
-      - ``truncated``: True when the per-mode cap was hit.
-
-    Cross-mode notes:
-      - System posts (``type`` starts with ``"system_"`` — channel joins, adds,
-        topic changes) appear in ``unread_only`` and ``since`` responses but are
-        NOT counted in ``unread_msg_count`` from ``list_my_channels``. Filter on
-        the prefix to skip them when only user content matters.
-      - Collapsed Reply Threads (CRT): with CRT off (team default),
-        ``unread_msg_count`` from ``list_my_channels`` counts thread replies too.
-        With CRT on, set ``collapsed_threads=True`` (valid only with
-        ``unread_only`` or ``since``) so the response matches the root-only
-        counter; use ``get_thread`` to fetch full threads when reply context is
-        needed.
-
-    For keyword search across channels, use ``search_messages`` instead.
-    To read every message in a thread, use ``get_thread``.
+    For keyword search use ``search_messages``; for full threads use ``get_thread``.
     """
     _validate_get_channel_messages_mode(
         unread_only=unread_only,

--- a/src/mcp_server_mattermost/tools/messages.py
+++ b/src/mcp_server_mattermost/tools/messages.py
@@ -145,42 +145,63 @@ async def get_channel_messages(  # noqa: PLR0913
     ] = False,
     client: MattermostClient = Depends(get_client),  # noqa: B008
 ) -> PostList:
-    """Get messages from a channel — recent, unread window, or modified since a timestamp.
+    """Get messages from a channel — recent history, the user's unread window, or posts changed since a watermark.
 
-    Three mutually-exclusive modes:
+    Three mutually-exclusive modes. Pick by user intent:
 
-    - **Default (page/per_page):** last ``per_page`` messages, reverse-chronological.
-      Suitable for "show me recent messages".
-    - **``unread_only=True``:** the user's unread window via ``/posts/unread``.
-      Returns up to ``limit_after`` unread posts plus ``limit_before`` context posts.
-      Deterministic ordering; edits of older posts do not appear. Preferred mode for
-      "show me what's new".
-    - **``since=<ms>``:** posts with ``update_at > since`` via ``?since=``. Includes
-      edits of older posts and thread replies. Use for incremental sync where the agent
-      tracks its own watermark. Posts are ordered by ``create_at``; the server caps the
-      response at 1000 posts, and when the cap is hit, returned posts are not guaranteed
-      to be consecutive (gaps are possible) — check ``truncated`` on the response.
+      - "Show me the last N messages" / "what's in this channel" → default
+        (page, per_page).
+      - "What did I miss" / "catch me up" → unread_only=True.
+      - "Sync everything modified since <ms>" → since=<unix_ms>.
 
-    Returns messages in reverse chronological order.
-    For searching messages by keywords across channels, use search_messages instead.
-    To read all messages in a thread, use get_thread.
+    Mode behavior:
 
-    Notes for agents:
-        - CRT-aware counters: with CRT off (team default), ``unread_msg_count``
-          from list_my_channels counts thread replies; with CRT on it doesn't.
-          The ``_root`` variants always count only root posts. Set
-          ``collapsed_threads=True`` (with ``unread_only`` or ``since``) when
-          the user has CRT on.
-        - ``since`` includes edits and deletions of older posts. Filter by
-          ``create_at > since`` for new posts only; check ``delete_at == 0``
-          to skip tombstones. System posts (``type`` starts with ``"system_"``)
-          appear in both modes but are not counted in ``unread_msg_count``.
-        - On a never-viewed channel ``last_viewed_at`` may be 0, in which case
-          ``unread_only`` returns an empty ``order``. Call ``mark_channel_viewed``
-          once after the channel has at least one post to bootstrap.
-        - ``truncated=True`` means more posts exist beyond this batch. Increase
-          ``limit_after`` (up to 200), narrow the ``since`` window, or use one of
-          the bot-loop patterns in docs/examples.md ("Bot Monitor Loop").
+    - **Default** (page, per_page): the most recent posts in reverse-chronological
+      order. ``truncated=True`` when the page is full and more posts likely exist;
+      paginate with ``page+1``.
+
+    - **unread_only=True** (with limit_before, limit_after): the user's unread
+      window, anchored at Mattermost's read marker ``last_viewed_at``. Returns up
+      to ``limit_after`` unread posts plus ``limit_before`` already-read posts as
+      context. Edits of older posts are NOT included. Deleted posts are excluded.
+      On a never-viewed channel (``last_viewed_at == 0``) ``order`` comes back
+      empty even when ``unread_msg_count > 0`` — call ``mark_channel_viewed`` once
+      after the channel has at least one post to bootstrap.
+
+    - **since=<unix_ms>**: posts with ``update_at > since``, ordered by
+      ``create_at``. Use when the caller tracks its own watermark, or when edits
+      and deletes of older posts also matter. Includes:
+          * edits of older posts (``create_at <= since AND update_at > since``);
+          * tombstones for deletions (``delete_at != 0``, empty ``message``,
+            ``props.deleteBy`` set);
+          * cascade updates — a root post's ``update_at`` advances when any reply
+            in its thread is edited or deleted, even if the root itself didn't
+            change.
+      Filter by ``create_at > since`` for newly-created posts only; check
+      ``delete_at == 0`` for live messages only. The server caps the response at
+      1000 posts; when ``truncated=True`` the returned posts may not be
+      contiguous (gaps possible) — step ``since`` forward in smaller windows.
+
+    Returns an object with:
+      - ``order``: list of post IDs in reverse-chronological order;
+      - ``posts``: dict of post objects keyed by ID — may contain more entries
+        than ``order`` (e.g. root posts referenced by thread replies);
+      - ``truncated``: True when the per-mode cap was hit.
+
+    Cross-mode notes:
+      - System posts (``type`` starts with ``"system_"`` — channel joins, adds,
+        topic changes) appear in ``unread_only`` and ``since`` responses but are
+        NOT counted in ``unread_msg_count`` from ``list_my_channels``. Filter on
+        the prefix to skip them when only user content matters.
+      - Collapsed Reply Threads (CRT): with CRT off (team default),
+        ``unread_msg_count`` from ``list_my_channels`` counts thread replies too.
+        With CRT on, set ``collapsed_threads=True`` (valid only with
+        ``unread_only`` or ``since``) so the response matches the root-only
+        counter; use ``get_thread`` to fetch full threads when reply context is
+        needed.
+
+    For keyword search across channels, use ``search_messages`` instead.
+    To read every message in a thread, use ``get_thread``.
     """
     _validate_get_channel_messages_mode(
         unread_only=unread_only,

--- a/src/mcp_server_mattermost/tools/messages.py
+++ b/src/mcp_server_mattermost/tools/messages.py
@@ -54,28 +54,119 @@ async def post_message(  # noqa: PLR0913
     return Post(**data)
 
 
+_DEFAULT_PER_PAGE = 60
+
+
+def _validate_get_channel_messages_mode(
+    unread_only: bool,  # noqa: FBT001
+    since: int | None,
+    page: int,
+    per_page: int,
+) -> None:
+    """Raise ValueError if multiple read modes are combined.
+
+    Three modes are supported and mutually exclusive:
+      - unread_only=True            -> /posts/unread
+      - since=<ms>                  -> /posts?since=
+      - default (page/per_page)     -> /posts?page=&per_page=
+    """
+    if unread_only and since is not None:
+        msg = "unread_only=True and since=... are mutually exclusive — pick one mode"
+        raise ValueError(msg)
+    pagination_explicit = page != 0 or per_page != _DEFAULT_PER_PAGE
+    if (unread_only or since is not None) and pagination_explicit:
+        msg = (
+            "page/per_page cannot be combined with unread_only or since — pagination is only meaningful in default mode"
+        )
+        raise ValueError(msg)
+
+
 @tool(
     annotations={"readOnlyHint": True, "idempotentHint": True},
     tags={ToolTag.MATTERMOST, ToolTag.MESSAGE, ToolTag.CHANNEL},
     meta={"capability": Capability.READ},
 )
-async def get_channel_messages(
+async def get_channel_messages(  # noqa: PLR0913
     channel_id: ChannelId,
+    unread_only: Annotated[  # noqa: FBT002
+        bool,
+        Field(description="Return only the user's unread window via /posts/unread"),
+    ] = False,
+    since: Annotated[
+        int | None,
+        Field(
+            ge=1_000_000_000_000,
+            description=(
+                "Unix timestamp in milliseconds (>= 10^12, i.e. >= 2001-01-01); return "
+                "posts modified after this time. Mutually exclusive with unread_only and "
+                "pagination. Use ChannelWithUnreads.last_viewed_at from list_my_channels."
+            ),
+        ),
+    ] = None,
     page: Annotated[int, Field(ge=0, description="Page number (0-indexed)")] = 0,
-    per_page: Annotated[int, Field(ge=1, le=200, description="Results per page")] = 60,
+    per_page: Annotated[int, Field(ge=1, le=200, description="Results per page")] = _DEFAULT_PER_PAGE,
+    limit_before: Annotated[  # noqa: ARG001
+        int,
+        Field(
+            ge=0,
+            le=200,
+            description="In unread_only mode: read context posts before the first unread (max 200)",
+        ),
+    ] = 0,
+    limit_after: Annotated[  # noqa: ARG001
+        int,
+        Field(
+            ge=0,
+            le=200,
+            description="In unread_only mode: unread posts to return (max 200)",
+        ),
+    ] = _DEFAULT_PER_PAGE,
+    collapsed_threads: Annotated[  # noqa: FBT002, ARG001
+        bool,
+        Field(
+            description=(
+                "Set True only if the user has CRT (Collapsed Reply Threads) enabled. "
+                "Team default is CRT off — leave False unless you know otherwise."
+            ),
+        ),
+    ] = False,
     client: MattermostClient = Depends(get_client),  # noqa: B008
 ) -> PostList:
-    """Get recent messages from a channel.
+    """Get messages from a channel — recent, unread window, or modified since a timestamp.
 
-    Returns messages in reverse chronological order (newest first).
-    Use for reading channel conversation history.
+    Three mutually-exclusive modes:
+
+    - **Default (page/per_page):** last ``per_page`` messages, reverse-chronological.
+      Suitable for "show me recent messages".
+    - **``unread_only=True``:** the user's unread window via ``/posts/unread``.
+      Returns up to ``limit_after`` unread posts plus ``limit_before`` context posts.
+      Deterministic ordering; edits of older posts do not appear. Preferred mode for
+      "show me what's new".
+    - **``since=<ms>``:** posts with ``update_at > since`` via ``?since=``. Includes
+      edits of older posts and thread replies. Use for incremental sync where the agent
+      tracks its own watermark. Server hard-caps at 1000 posts without a deterministic
+      order — check ``truncated`` on the response.
+
+    Returns messages in reverse chronological order.
     For searching messages by keywords across channels, use search_messages instead.
+    To read all messages in a thread, use get_thread.
+
+    Notes for agents:
+        - When CRT is OFF (team default), ``unread_msg_count`` from list_my_channels
+          covers both root posts and thread replies; this tool's response in any mode
+          also covers both.
+        - When CRT is ON, ``unread_msg_count`` in list_my_channels excludes thread
+          replies. Pass ``collapsed_threads=True`` and fetch full threads via get_thread
+          when needed.
+        - In ``since`` mode, edits of older posts (``create_at <= since AND
+          update_at > since``) appear in the response. Filter by ``create_at > since``
+          if you only want newly-created messages.
+        - If ``response.truncated`` is True, more posts exist beyond this batch.
+          In ``since`` mode, switch to ``unread_only=True`` for deterministic results.
     """
-    data = await client.get_posts(
-        channel_id=channel_id,
-        page=page,
-        per_page=per_page,
-    )
+    _validate_get_channel_messages_mode(unread_only=unread_only, since=since, page=page, per_page=per_page)
+    # Routing to unread_only / since branches is implemented in Task 5.
+    data = await client.get_posts(channel_id=channel_id, page=page, per_page=per_page)
     return PostList(**data)
 
 

--- a/src/mcp_server_mattermost/tools/messages.py
+++ b/src/mcp_server_mattermost/tools/messages.py
@@ -105,7 +105,7 @@ async def get_channel_messages(  # noqa: PLR0913
     ] = None,
     page: Annotated[int, Field(ge=0, description="Page number (0-indexed)")] = 0,
     per_page: Annotated[int, Field(ge=1, le=200, description="Results per page")] = _DEFAULT_PER_PAGE,
-    limit_before: Annotated[  # noqa: ARG001
+    limit_before: Annotated[
         int,
         Field(
             ge=0,
@@ -113,7 +113,7 @@ async def get_channel_messages(  # noqa: PLR0913
             description="In unread_only mode: read context posts before the first unread (max 200)",
         ),
     ] = 0,
-    limit_after: Annotated[  # noqa: ARG001
+    limit_after: Annotated[
         int,
         Field(
             ge=0,
@@ -121,7 +121,7 @@ async def get_channel_messages(  # noqa: PLR0913
             description="In unread_only mode: unread posts to return (max 200)",
         ),
     ] = _DEFAULT_PER_PAGE,
-    collapsed_threads: Annotated[  # noqa: FBT002, ARG001
+    collapsed_threads: Annotated[  # noqa: FBT002
         bool,
         Field(
             description=(
@@ -165,9 +165,30 @@ async def get_channel_messages(  # noqa: PLR0913
           In ``since`` mode, switch to ``unread_only=True`` for deterministic results.
     """
     _validate_get_channel_messages_mode(unread_only=unread_only, since=since, page=page, per_page=per_page)
-    # Routing to unread_only / since branches is implemented in Task 5.
-    data = await client.get_posts(channel_id=channel_id, page=page, per_page=per_page)
-    return PostList(**data)
+
+    if unread_only:
+        data = await client.get_channel_posts_unread(
+            channel_id=channel_id,
+            limit_before=limit_before,
+            limit_after=limit_after,
+            collapsed_threads=collapsed_threads,
+        )
+        cap = max(1, limit_before + limit_after)
+    elif since is not None:
+        data = await client.get_posts_since(
+            channel_id=channel_id,
+            since=since,
+            collapsed_threads=collapsed_threads,
+        )
+        cap = 1000
+    else:
+        data = await client.get_posts(channel_id=channel_id, page=page, per_page=per_page)
+        cap = per_page
+
+    post_list = PostList(**data)
+    if len(post_list.order) >= cap:
+        post_list = post_list.model_copy(update={"truncated": True})
+    return post_list
 
 
 @tool(

--- a/src/mcp_server_mattermost/tools/messages.py
+++ b/src/mcp_server_mattermost/tools/messages.py
@@ -62,6 +62,7 @@ def _validate_get_channel_messages_mode(
     since: int | None,
     page: int,
     per_page: int,
+    collapsed_threads: bool,  # noqa: FBT001
 ) -> None:
     """Raise ValueError if multiple read modes are combined.
 
@@ -69,6 +70,10 @@ def _validate_get_channel_messages_mode(
       - unread_only=True            -> /posts/unread
       - since=<ms>                  -> /posts?since=
       - default (page/per_page)     -> /posts?page=&per_page=
+
+    ``collapsed_threads`` is a CRT-aware flag accepted only by the unread and
+    since endpoints; the default /posts endpoint does not accept it, so
+    ``collapsed_threads=True`` is rejected in default mode.
     """
     if unread_only and since is not None:
         msg = "unread_only=True and since=... are mutually exclusive — pick one mode"
@@ -77,6 +82,12 @@ def _validate_get_channel_messages_mode(
     if (unread_only or since is not None) and pagination_explicit:
         msg = (
             "page/per_page cannot be combined with unread_only or since — pagination is only meaningful in default mode"
+        )
+        raise ValueError(msg)
+    if collapsed_threads and not unread_only and since is None:
+        msg = (
+            "collapsed_threads=True requires unread_only=True or since=<ms> — "
+            "the default /posts endpoint does not support CRT-aware queries"
         )
         raise ValueError(msg)
 
@@ -116,9 +127,9 @@ async def get_channel_messages(  # noqa: PLR0913
     limit_after: Annotated[
         int,
         Field(
-            ge=0,
+            ge=1,
             le=200,
-            description="In unread_only mode: unread posts to return (max 200)",
+            description="In unread_only mode: unread posts to return (1-200)",
         ),
     ] = _DEFAULT_PER_PAGE,
     collapsed_threads: Annotated[  # noqa: FBT002
@@ -126,7 +137,9 @@ async def get_channel_messages(  # noqa: PLR0913
         Field(
             description=(
                 "Set True only if the user has CRT (Collapsed Reply Threads) enabled. "
-                "Team default is CRT off — leave False unless you know otherwise."
+                "Team default is CRT off — leave False unless you know otherwise. "
+                "Requires unread_only=True or since=<ms>; the default /posts endpoint "
+                "rejects CRT-aware queries."
             ),
         ),
     ] = False,
@@ -144,27 +157,38 @@ async def get_channel_messages(  # noqa: PLR0913
       "show me what's new".
     - **``since=<ms>``:** posts with ``update_at > since`` via ``?since=``. Includes
       edits of older posts and thread replies. Use for incremental sync where the agent
-      tracks its own watermark. Server hard-caps at 1000 posts without a deterministic
-      order — check ``truncated`` on the response.
+      tracks its own watermark. Posts are ordered by ``create_at``; the server caps the
+      response at 1000 posts, and when the cap is hit, returned posts are not guaranteed
+      to be consecutive (gaps are possible) — check ``truncated`` on the response.
 
     Returns messages in reverse chronological order.
     For searching messages by keywords across channels, use search_messages instead.
     To read all messages in a thread, use get_thread.
 
     Notes for agents:
-        - When CRT is OFF (team default), ``unread_msg_count`` from list_my_channels
-          covers both root posts and thread replies; this tool's response in any mode
-          also covers both.
-        - When CRT is ON, ``unread_msg_count`` in list_my_channels excludes thread
-          replies. Pass ``collapsed_threads=True`` and fetch full threads via get_thread
-          when needed.
-        - In ``since`` mode, edits of older posts (``create_at <= since AND
-          update_at > since``) appear in the response. Filter by ``create_at > since``
-          if you only want newly-created messages.
-        - If ``response.truncated`` is True, more posts exist beyond this batch.
-          In ``since`` mode, switch to ``unread_only=True`` for deterministic results.
+        - CRT-aware counters: with CRT off (team default), ``unread_msg_count``
+          from list_my_channels counts thread replies; with CRT on it doesn't.
+          The ``_root`` variants always count only root posts. Set
+          ``collapsed_threads=True`` (with ``unread_only`` or ``since``) when
+          the user has CRT on.
+        - ``since`` includes edits and deletions of older posts. Filter by
+          ``create_at > since`` for new posts only; check ``delete_at == 0``
+          to skip tombstones. System posts (``type`` starts with ``"system_"``)
+          appear in both modes but are not counted in ``unread_msg_count``.
+        - On a never-viewed channel ``last_viewed_at`` may be 0, in which case
+          ``unread_only`` returns an empty ``order``. Call ``mark_channel_viewed``
+          once after the channel has at least one post to bootstrap.
+        - ``truncated=True`` means more posts exist beyond this batch. Increase
+          ``limit_after`` (up to 200), narrow the ``since`` window, or use one of
+          the bot-loop patterns in docs/examples.md ("Bot Monitor Loop").
     """
-    _validate_get_channel_messages_mode(unread_only=unread_only, since=since, page=page, per_page=per_page)
+    _validate_get_channel_messages_mode(
+        unread_only=unread_only,
+        since=since,
+        page=page,
+        per_page=per_page,
+        collapsed_threads=collapsed_threads,
+    )
 
     if unread_only:
         data = await client.get_channel_posts_unread(

--- a/tests/integration/test_unread_flow.py
+++ b/tests/integration/test_unread_flow.py
@@ -1,0 +1,27 @@
+"""Integration test: list_my_channels -> get_channel_messages(unread_only) flow."""
+
+import pytest
+
+from tests.integration.utils import to_dict
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_unread_flow_against_real_server(mcp_client, mattermost_env) -> None:
+    """Agent can list unread channels and fetch their unread windows in one MCP session."""
+    channels_result = await mcp_client.call_tool(
+        "list_my_channels", {"team_id": mattermost_env.team_id, "only_unread": True}
+    )
+    channels = to_dict(channels_result)
+    for ch in channels:
+        assert "last_viewed_at" in ch
+        assert isinstance(ch["last_viewed_at"], int)
+
+    for ch in channels:
+        posts_result = await mcp_client.call_tool(
+            "get_channel_messages",
+            {"channel_id": ch["id"], "unread_only": True, "limit_after": 200},
+        )
+        posts = to_dict(posts_result)
+        assert "truncated" in posts
+        assert len(posts["order"]) <= 200

--- a/tests/models/test_post.py
+++ b/tests/models/test_post.py
@@ -117,3 +117,15 @@ def test_reaction_parses():
 
     reaction = Reaction(**data)
     assert reaction.emoji_name == "thumbsup"
+
+
+def test_post_list_truncated_default_false() -> None:
+    """truncated defaults to False — most responses are complete."""
+    pl = PostList(order=[], posts={})
+    assert pl.truncated is False
+
+
+def test_post_list_truncated_can_be_set() -> None:
+    """Tools may set truncated=True after detecting a cap hit."""
+    pl = PostList(order=[], posts={}, truncated=True)
+    assert pl.truncated is True

--- a/tests/test_capability_meta.py
+++ b/tests/test_capability_meta.py
@@ -16,6 +16,7 @@ EXPECTED_CAPABILITIES: dict[str, Capability] = {
     "create_channel": Capability.CREATE,
     "join_channel": Capability.WRITE,
     "leave_channel": Capability.WRITE,
+    "mark_channel_viewed": Capability.WRITE,
     "get_channel_members": Capability.READ,
     "add_user_to_channel": Capability.WRITE,
     "create_direct_channel": Capability.CREATE,
@@ -181,7 +182,7 @@ class TestCapabilityCounts:
 
     def test_expected_tool_count(self):
         """Total tool count matches expectations."""
-        assert len(EXPECTED_CAPABILITIES) == 37
+        assert len(EXPECTED_CAPABILITIES) == 38
 
     def test_capability_distribution(self):
         """Capability distribution matches design."""
@@ -189,6 +190,6 @@ class TestCapabilityCounts:
         for cap in EXPECTED_CAPABILITIES.values():
             counts[cap] = counts.get(cap, 0) + 1
         assert counts[Capability.READ] == 20
-        assert counts[Capability.WRITE] == 13
+        assert counts[Capability.WRITE] == 14
         assert counts[Capability.CREATE] == 2
         assert counts[Capability.DELETE] == 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1151,6 +1151,31 @@ class TestMattermostClientChannelsAPI:
 
         assert result == {"channel_id": "ch123", "user_id": "user456"}
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_view_channel_marks_channel_viewed(self, mock_settings):
+        """view_channel POSTs /channels/members/me/view with {"channel_id": ...}."""
+        import json
+
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        client = MattermostClient(settings)
+
+        route = respx.post(
+            "https://test.mattermost.com/api/v4/channels/members/me/view",
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"status": "OK", "last_viewed_at_times": {"ch1": 1716620000000}},
+            )
+        )
+        async with client.lifespan():
+            await client.view_channel(channel_id="ch1")
+        assert route.called
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"channel_id": "ch1"}
+
 
 class TestMattermostClientMessagesAPI:
     """Test Messages/Posts API methods."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1214,6 +1214,47 @@ class TestMattermostClientMessagesAPI:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_get_channel_posts_unread_passes_limits(self, mock_settings):
+        """get_channel_posts_unread must call /users/me/channels/{id}/posts/unread with limits."""
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        client = MattermostClient(settings)
+        route = respx.get("https://test.mattermost.com/api/v4/users/me/channels/ch1/posts/unread").mock(
+            return_value=httpx.Response(200, json={"order": [], "posts": {}})
+        )
+        async with client.lifespan():
+            await client.get_channel_posts_unread(
+                channel_id="ch1",
+                limit_before=10,
+                limit_after=100,
+            )
+        assert route.called
+        assert route.calls[0].request.url.params["limit_before"] == "10"
+        assert route.calls[0].request.url.params["limit_after"] == "100"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_channel_posts_unread_with_collapsed_threads(self, mock_settings):
+        """collapsed_threads=True must propagate as collapsedThreads query param."""
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        client = MattermostClient(settings)
+        route = respx.get("https://test.mattermost.com/api/v4/users/me/channels/ch1/posts/unread").mock(
+            return_value=httpx.Response(200, json={"order": [], "posts": {}})
+        )
+        async with client.lifespan():
+            await client.get_channel_posts_unread(
+                channel_id="ch1",
+                limit_before=0,
+                limit_after=60,
+                collapsed_threads=True,
+            )
+        assert route.calls[0].request.url.params["collapsedThreads"] == "true"
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_create_post(self, mock_settings):
         """create_post() should create a new post."""
         import json

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1179,6 +1179,41 @@ class TestMattermostClientMessagesAPI:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_get_posts_since_passes_since_param(self, mock_settings):
+        """get_posts_since must call /channels/{id}/posts with the since query param."""
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        client = MattermostClient(settings)
+
+        route = respx.get("https://test.mattermost.com/api/v4/channels/ch1/posts").mock(
+            return_value=httpx.Response(200, json={"order": [], "posts": {}})
+        )
+        async with client.lifespan():
+            await client.get_posts_since(channel_id="ch1", since=1716620000000)
+        assert route.called
+        assert route.calls[0].request.url.params["since"] == "1716620000000"
+        assert "page" not in route.calls[0].request.url.params
+        assert "per_page" not in route.calls[0].request.url.params
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_posts_since_with_collapsed_threads(self, mock_settings):
+        """collapsed_threads=True must propagate to query params."""
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        client = MattermostClient(settings)
+
+        route = respx.get("https://test.mattermost.com/api/v4/channels/ch1/posts").mock(
+            return_value=httpx.Response(200, json={"order": [], "posts": {}})
+        )
+        async with client.lifespan():
+            await client.get_posts_since(channel_id="ch1", since=1716620000000, collapsed_threads=True)
+        assert route.calls[0].request.url.params["collapsedThreads"] == "true"
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_create_post(self, mock_settings):
         """create_post() should create a new post."""
         import json

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,7 +62,7 @@ class TestServerIntegration:
         from mcp_server_mattermost.server import mcp
 
         tools = await mcp.list_tools()
-        assert len(tools) == 37, f"Expected 37 tools, got {len(tools)}: {[t.name for t in tools]}"
+        assert len(tools) == 38, f"Expected 38 tools, got {len(tools)}: {[t.name for t in tools]}"
 
 
 class TestMcpAuth:

--- a/tests/test_tools/test_channels.py
+++ b/tests/test_tools/test_channels.py
@@ -448,3 +448,19 @@ class TestErrorHandling:
                 channel_id="ch1234567890123456789012",
                 client=mock_client_not_found,
             )
+
+
+class TestMarkChannelViewed:
+    """Tests for mark_channel_viewed tool."""
+
+    async def test_mark_channel_viewed_delegates_to_client(self, mock_client: AsyncMock) -> None:
+        """Tool calls client.view_channel with the channel_id and returns None."""
+        mock_client.view_channel.return_value = None
+
+        result = await channels.mark_channel_viewed(
+            channel_id="ch1234567890123456789012",
+            client=mock_client,
+        )
+
+        assert result is None
+        mock_client.view_channel.assert_called_once_with(channel_id="ch1234567890123456789012")

--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -266,3 +266,50 @@ class TestErrorHandling:
                 terms="test",
                 client=mock_client_rate_limited,
             )
+
+
+class TestGetChannelMessagesValidation:
+    """Tests for get_channel_messages mode-exclusivity validation."""
+
+    async def test_rejects_unread_only_with_since(self, mock_settings) -> None:
+        """unread_only=True with since=... must raise — modes are mutually exclusive."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception) as exc_info:
+                await client.call_tool(
+                    "get_channel_messages",
+                    {"channel_id": "ch123456789012345678901234", "unread_only": True, "since": 1716620000000},
+                )
+        msg = str(exc_info.value).lower()
+        assert "mutually exclusive" in msg or "cannot use both" in msg
+
+    async def test_rejects_unread_only_with_pagination(self, mock_settings) -> None:
+        """unread_only=True with non-default page must raise."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception) as exc_info:
+                await client.call_tool(
+                    "get_channel_messages",
+                    {"channel_id": "ch123456789012345678901234", "unread_only": True, "page": 2},
+                )
+        msg = str(exc_info.value).lower()
+        assert "page" in msg or "mutually exclusive" in msg or "pagination" in msg
+
+    async def test_rejects_since_in_seconds(self, mock_settings) -> None:
+        """since must be Unix milliseconds — values below 10^12 are rejected."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception):  # noqa: B017
+                await client.call_tool(
+                    "get_channel_messages",
+                    {"channel_id": "ch123456789012345678901234", "since": 1716620000},  # seconds not ms
+                )

--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+import respx
 
 from mcp_server_mattermost.exceptions import AuthenticationError, RateLimitError
 from mcp_server_mattermost.models import Post, PostList
@@ -313,3 +315,157 @@ class TestGetChannelMessagesValidation:
                     "get_channel_messages",
                     {"channel_id": "ch123456789012345678901234", "since": 1716620000},  # seconds not ms
                 )
+
+
+def _post_fixture(**overrides) -> dict:  # type: ignore[type-arg]
+    base = {
+        "id": "p",
+        "create_at": 1,
+        "update_at": 1,
+        "delete_at": 0,
+        "edit_at": 0,
+        "user_id": "u",
+        "channel_id": "ch",
+        "root_id": "",
+        "original_id": "",
+        "message": "hi",
+        "type": "",
+        "hashtags": "",
+        "file_ids": [],
+        "pending_post_id": "",
+        "is_pinned": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestGetChannelMessagesRouting:
+    """Tests for get_channel_messages routing and truncation detection."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unread_mode_calls_posts_unread(self, mock_settings) -> None:
+        """unread_only=True must hit /users/me/channels/{id}/posts/unread."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        route = respx.get(
+            "https://test.mattermost.com/api/v4/users/me/channels/ch123456789012345678901234/posts/unread"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "order": ["p1"],
+                    "posts": {"p1": _post_fixture(id="p1", channel_id="ch123456789012345678901234")},
+                },
+            )
+        )
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_channel_messages",
+                {"channel_id": "ch123456789012345678901234", "unread_only": True, "limit_after": 100},
+            )
+        assert route.called
+        assert result.structured_content["order"] == ["p1"]
+        assert result.structured_content["truncated"] is False
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_since_mode_calls_posts_with_since_param(self, mock_settings) -> None:
+        """since=<ms> must hit /channels/{id}/posts with since query param."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        route = respx.get("https://test.mattermost.com/api/v4/channels/ch123456789012345678901234/posts").mock(
+            return_value=httpx.Response(200, json={"order": [], "posts": {}})
+        )
+        async with Client(mcp) as client:
+            await client.call_tool(
+                "get_channel_messages",
+                {"channel_id": "ch123456789012345678901234", "since": 1716620000000},
+            )
+        assert route.called
+        assert route.calls[0].request.url.params["since"] == "1716620000000"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_default_mode_calls_posts_with_pagination(self, mock_settings) -> None:
+        """Default mode preserves existing pagination behavior."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        route = respx.get("https://test.mattermost.com/api/v4/channels/ch123456789012345678901234/posts").mock(
+            return_value=httpx.Response(200, json={"order": [], "posts": {}})
+        )
+        async with Client(mcp) as client:
+            await client.call_tool("get_channel_messages", {"channel_id": "ch123456789012345678901234"})
+        assert route.called
+        assert route.calls[0].request.url.params["per_page"] == "60"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_truncated_when_unread_hits_cap(self, mock_settings) -> None:
+        """truncated=True when len(order) >= limit_before + limit_after."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        posts = {f"p{i}": _post_fixture(id=f"p{i}", channel_id="ch123456789012345678901234") for i in range(2)}
+        respx.get("https://test.mattermost.com/api/v4/users/me/channels/ch123456789012345678901234/posts/unread").mock(
+            return_value=httpx.Response(200, json={"order": list(posts), "posts": posts})
+        )
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_channel_messages",
+                {"channel_id": "ch123456789012345678901234", "unread_only": True, "limit_after": 2},
+            )
+        assert result.structured_content["truncated"] is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_truncated_when_since_hits_1000(self, mock_settings) -> None:
+        """truncated=True when since-mode response has exactly 1000 posts in order."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        posts = {f"p{i}": _post_fixture(id=f"p{i}", channel_id="ch123456789012345678901234") for i in range(1000)}
+        respx.get("https://test.mattermost.com/api/v4/channels/ch123456789012345678901234/posts").mock(
+            return_value=httpx.Response(200, json={"order": list(posts), "posts": posts})
+        )
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_channel_messages",
+                {"channel_id": "ch123456789012345678901234", "since": 1716620000000},
+            )
+        assert result.structured_content["truncated"] is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_since_thread_context_does_not_falsely_truncate(self, mock_settings) -> None:
+        """truncated must check len(order) not len(posts).
+
+        950 posts in order + 50 context roots in posts (not in order) = len(posts)=1000
+        but len(order)=950 < 1000 -> NOT truncated.
+        """
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        order = [f"p{i}" for i in range(950)]
+        posts = {p: _post_fixture(id=p, channel_id="ch123456789012345678901234") for p in order}
+        for i in range(50):
+            ctx = f"ctx{i}"
+            posts[ctx] = _post_fixture(id=ctx, channel_id="ch123456789012345678901234")
+        respx.get("https://test.mattermost.com/api/v4/channels/ch123456789012345678901234/posts").mock(
+            return_value=httpx.Response(200, json={"order": order, "posts": posts})
+        )
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_channel_messages",
+                {"channel_id": "ch123456789012345678901234", "since": 1716620000000},
+            )
+        assert result.structured_content["truncated"] is False

--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -91,6 +91,7 @@ class TestGetChannelMessages:
 
         assert isinstance(result, PostList)
         assert "ps1" in result.posts
+        assert result.truncated is False
 
 
 class TestSearchMessages:
@@ -316,6 +317,41 @@ class TestGetChannelMessagesValidation:
                     {"channel_id": "ch123456789012345678901234", "since": 1716620000},  # seconds not ms
                 )
 
+    async def test_rejects_collapsed_threads_with_default_mode(self, mock_settings) -> None:
+        """collapsed_threads=True without unread_only or since must raise."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception) as exc_info:
+                await client.call_tool(
+                    "get_channel_messages",
+                    {"channel_id": "ch123456789012345678901234", "collapsed_threads": True},
+                )
+        msg = str(exc_info.value).lower()
+        assert "collapsed_threads" in msg or "crt" in msg
+
+    @pytest.mark.asyncio
+    async def test_rejects_limit_after_zero(self, mock_settings) -> None:
+        """limit_after=0 must be rejected at validation; Mattermost API returns HTTP 400 for it."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception) as exc_info:
+                await client.call_tool(
+                    "get_channel_messages",
+                    {
+                        "channel_id": "ch123456789012345678901234",
+                        "unread_only": True,
+                        "limit_after": 0,
+                    },
+                )
+        msg = str(exc_info.value).lower()
+        assert "limit_after" in msg or "greater" in msg or "ge" in msg
+
 
 def _post_fixture(**overrides) -> dict:  # type: ignore[type-arg]
     base = {
@@ -440,6 +476,25 @@ class TestGetChannelMessagesRouting:
             result = await client.call_tool(
                 "get_channel_messages",
                 {"channel_id": "ch123456789012345678901234", "since": 1716620000000},
+            )
+        assert result.structured_content["truncated"] is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_truncated_when_default_hits_per_page(self, mock_settings) -> None:
+        """truncated=True when default-mode response has len(order) >= per_page."""
+        from fastmcp import Client
+
+        from mcp_server_mattermost.server import mcp
+
+        posts = {f"p{i}": _post_fixture(id=f"p{i}", channel_id="ch123456789012345678901234") for i in range(3)}
+        respx.get("https://test.mattermost.com/api/v4/channels/ch123456789012345678901234/posts").mock(
+            return_value=httpx.Response(200, json={"order": list(posts), "posts": posts})
+        )
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_channel_messages",
+                {"channel_id": "ch123456789012345678901234", "per_page": 3},
             )
         assert result.structured_content["truncated"] is True
 

--- a/tests/test_tools/test_tool_tags.py
+++ b/tests/test_tools/test_tool_tags.py
@@ -13,6 +13,7 @@ for _tool in (
     "create_channel",
     "join_channel",
     "leave_channel",
+    "mark_channel_viewed",
     "get_channel_members",
     "add_user_to_channel",
     "create_direct_channel",
@@ -82,7 +83,7 @@ class TestToolCount:
     """Verify expected number of tools are registered."""
 
     async def test_total_tool_count(self, all_tools):
-        assert len(all_tools) == 37, f"Expected 37 tools, got {len(all_tools)}: {list(all_tools.keys())}"
+        assert len(all_tools) == 38, f"Expected 38 tools, got {len(all_tools)}: {list(all_tools.keys())}"
 
     async def test_no_unexpected_tools(self, all_tools):
         """Catch new tools not in _TOOL_TO_MODULE."""


### PR DESCRIPTION
## Summary

Builds on PR #8 (`list_my_channels` unread enrichment) to close the read loop.

- `get_channel_messages` gains two mutually-exclusive modes:
  - `unread_only=True` — the user's unread window via `/users/me/channels/{id}/posts/unread`, with `limit_before`/`limit_after` bounds and a `collapsed_threads` flag for CRT-on users.
  - `since=<unix_ms>` — posts modified after a timestamp via `?since=`, suitable for incremental sync. Surfaces edits of older posts, tombstones for deletions, and cascade updates from thread activity.
- `PostList.truncated` — `True` when the response hit the per-mode cap (default: `per_page`; `unread_only`: `limit_before + limit_after`; `since`: 1000 server hard-cap).
- New `mark_channel_viewed` tool — advances the channel read marker for the authenticated user. Bootstrap path for `last_viewed_at == 0` and bot polling loops.
- Mode-exclusivity validation rejects combined `unread_only` + `since`, pagination mixed with either, and `collapsed_threads=True` in default mode.
- `limit_after` tightened to `1-200` after end-to-end testing surfaced `limit_after=0 → HTTP 400` from Mattermost.

## Docs

- `docs/examples.md` — "Morning Catch-Up" rewritten around the unread window; new "Bot Monitor Loop" recipe with two patterns (simple `unread_only + mark_channel_viewed`, at-least-once `since + external watermark`).
- `docs/tools/messages.md` — three-mode section with CRT and `since`-cap notes.
- `docs/tools/channels.md` — `mark_channel_viewed` and the `only_unread` filter on `list_my_channels`.
- Tool docstrings rewritten to be self-contained for agent consumption (no external references) and compressed to footgun-only notes to keep the context budget small.

## Test plan

- [x] 572 unit tests pass; mode-exclusivity, `truncated` flagging, `limit_after` validation, system-post filtering all covered.
- [x] Integration test `tests/integration/test_unread_flow.py` verifies `list_my_channels(only_unread=True) → get_channel_messages(unread_only=True)` end-to-end.
- [x] Manual end-to-end against a real Mattermost server: bot + human accounts, CRT off/on toggle, 220-post scale on `since`, never-viewed bootstrap path, admin no-op on non-member channels.
- [x] `uv run ruff check src tests`, `uv run ruff format --check src tests`, `uv run mypy src` — clean.