### PR TITLE
feat: support MATTERMOST_EXTRA_CA_CERTS for corporate CAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `MATTERMOST_EXTRA_CA_CERTS` — path to a PEM file with additional CA
+  certificates (corporate/private CAs). Unlike `SSL_CERT_FILE` /
+  `REQUESTS_CA_BUNDLE`, which *replace* the trust store, the extra CAs are
+  appended to the default bundle, so publicly-signed hosts keep working. The
+  combined bundle applies to all outgoing HTTPS requests, including the OAuth
+  proxy's token exchange with the identity provider.
+
 ## [0.5.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Once configured, you can ask your AI assistant:
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |
+| `MATTERMOST_EXTRA_CA_CERTS` | No | — | Path to extra PEM CAs appended to the default trust store |
 | `MATTERMOST_LOG_LEVEL` | No | INFO | Logging level |
 | `MATTERMOST_LOG_FORMAT` | No | json | Log output format: `json` or `text` |
 | `MATTERMOST_API_VERSION` | No | v4 | Mattermost API version |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 | `MATTERMOST_TIMEOUT` | 30 | Request timeout in seconds (1-300) |
 | `MATTERMOST_MAX_RETRIES` | 3 | Maximum retry attempts for failed requests (0-10) |
 | `MATTERMOST_VERIFY_SSL` | true | Verify SSL certificates |
-| `MATTERMOST_EXTRA_CA_CERTS` | — | Path to a PEM file with additional CA certificates (corporate/private CAs) appended to the default trust store for all outgoing HTTPS requests |
+| `MATTERMOST_EXTRA_CA_CERTS` | — | Path to extra PEM CAs appended to the default trust store |
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 | `MATTERMOST_TIMEOUT` | 30 | Request timeout in seconds (1-300) |
 | `MATTERMOST_MAX_RETRIES` | 3 | Maximum retry attempts for failed requests (0-10) |
 | `MATTERMOST_VERIFY_SSL` | true | Verify SSL certificates |
+| `MATTERMOST_EXTRA_CA_CERTS` | — | Path to a PEM file with additional CA certificates (corporate/private CAs) appended to the default trust store for all outgoing HTTPS requests |
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -91,8 +91,21 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md#configuration-
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |
+| `MATTERMOST_EXTRA_CA_CERTS` | No | — | Path to mounted PEM CAs appended to the default trust store |
 | `MATTERMOST_LOG_LEVEL` | No | INFO | Logging level |
 | `MATTERMOST_LOG_FORMAT` | No | json | Log format: `json` or `text` |
+
+For private or corporate CAs, mount the PEM bundle and point
+`MATTERMOST_EXTRA_CA_CERTS` at the in-container path:
+
+```bash
+docker run -i --rm \
+  -v /etc/ssl/certs/corporate-ca.pem:/certs/corporate-ca.pem:ro \
+  -e MATTERMOST_URL=https://your-mattermost.com \
+  -e MATTERMOST_TOKEN=your-token \
+  -e MATTERMOST_EXTRA_CA_CERTS=/certs/corporate-ca.pem \
+  legard/mcp-server-mattermost
+```
 
 ### Transport Settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 
 dependencies = [
     "cachetools>=5.0",
+    "certifi",
     "fastmcp>=3.0.0,<4",
     "httpx>=0.28.0",
     "pydantic>=2.0",

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from functools import lru_cache
+from pathlib import Path
 from urllib.parse import urlsplit
 
 from pydantic import Field, field_validator, model_validator
@@ -49,6 +50,7 @@ class Settings(BaseSettings):
         MATTERMOST_TIMEOUT: Request timeout in seconds (default: 30)
         MATTERMOST_MAX_RETRIES: Max retry attempts (default: 3)
         MATTERMOST_VERIFY_SSL: Verify SSL certificates (default: true)
+        MATTERMOST_EXTRA_CA_CERTS: Path to PEM file with additional trusted CAs
         MATTERMOST_LOG_LEVEL: Logging level (default: INFO)
         MATTERMOST_LOG_FORMAT: Log format, 'json' or 'text' (default: json)
         MATTERMOST_API_VERSION: API version (default: v4)
@@ -71,6 +73,13 @@ class Settings(BaseSettings):
     timeout: int = Field(default=30, ge=1, le=300, description="Request timeout in seconds")
     max_retries: int = Field(default=3, ge=0, le=10, description="Maximum retry attempts")
     verify_ssl: bool = Field(default=True, description="Verify SSL certificates")
+    extra_ca_certs: str | None = Field(
+        default=None,
+        description=(
+            "Path to a PEM file with additional CA certificates appended to "
+            "the default trust store (corporate/private CAs)"
+        ),
+    )
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format: 'json' or 'text'")
     api_version: str = Field(default="v4", description="Mattermost API version")
@@ -106,6 +115,17 @@ class Settings(BaseSettings):
         if v is None:
             return v
         return v.rstrip("/")
+
+    @field_validator("extra_ca_certs")
+    @classmethod
+    def validate_extra_ca_certs(cls, v: str | None) -> str | None:
+        """Ensure the extra CA bundle exists when configured."""
+        if v is None or not v.strip():
+            return None
+        if not Path(v).is_file():
+            msg = f"MATTERMOST_EXTRA_CA_CERTS file not found: {v}"
+            raise ValueError(msg)
+        return v
 
     @field_validator("log_level")
     @classmethod

--- a/src/mcp_server_mattermost/server.py
+++ b/src/mcp_server_mattermost/server.py
@@ -13,6 +13,7 @@ from .auth_factory import build_auth_provider_from_env
 from .config import get_settings
 from .logging import logger, setup_logging
 from .middleware import LoggingMiddleware
+from .tls import install_extra_ca_certs
 
 
 @lifespan
@@ -46,6 +47,7 @@ def _create_mcp() -> FastMCP:
     Returns:
         Configured FastMCP server instance
     """
+    install_extra_ca_certs(get_settings())
     auth = build_auth_provider_from_env()
     return FastMCP(
         name="Mattermost",

--- a/src/mcp_server_mattermost/tls.py
+++ b/src/mcp_server_mattermost/tls.py
@@ -1,0 +1,65 @@
+"""Process-wide trust-store extension for outgoing HTTPS clients."""
+
+import os
+import ssl
+import tempfile
+from pathlib import Path
+
+import certifi
+
+from .config import Settings
+from .logging import logger
+
+
+_installed_bundle: str | None = None
+
+
+def install_extra_ca_certs(settings: Settings) -> str | None:
+    """Extend the default trust store with the CAs from ``extra_ca_certs``.
+
+    ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` *replace* the trust store used
+    by httpx and other OpenSSL-based clients rather than extending it, so
+    pointing them at a corporate-CA-only file silently breaks TLS to hosts
+    with publicly-signed certificates. To get append semantics, this builds a
+    combined PEM bundle — the current default bundle (an operator-provided
+    ``SSL_CERT_FILE`` or certifi's) plus the extra CAs — and points those
+    variables at it.
+
+    Must run before any HTTP client is created. Safe to call more than once;
+    subsequent calls return the already-installed bundle path.
+
+    Args:
+        settings: Validated application settings.
+
+    Returns:
+        Path of the combined bundle, or None when ``extra_ca_certs`` is unset.
+
+    Raises:
+        ConfigurationError: If the extra CA file is not valid PEM.
+    """
+    global _installed_bundle  # noqa: PLW0603
+    if not settings.extra_ca_certs:
+        return None
+    if _installed_bundle is not None:
+        return _installed_bundle
+
+    extra_path = Path(settings.extra_ca_certs)
+    try:
+        ssl.create_default_context().load_verify_locations(cafile=str(extra_path))
+    except ssl.SSLError as e:
+        from .exceptions import ConfigurationError  # noqa: PLC0415
+
+        msg = f"MATTERMOST_EXTRA_CA_CERTS is not a valid PEM CA bundle: {extra_path}"
+        raise ConfigurationError(msg) from e
+
+    base_path = Path(os.environ.get("SSL_CERT_FILE") or certifi.where())
+    with tempfile.NamedTemporaryFile("wb", prefix="mattermost-mcp-ca-", suffix=".pem", delete=False) as bundle:
+        bundle.write(base_path.read_bytes().rstrip() + b"\n")
+        bundle.write(extra_path.read_bytes())
+        bundle_path = bundle.name
+
+    os.environ["SSL_CERT_FILE"] = bundle_path
+    os.environ["REQUESTS_CA_BUNDLE"] = bundle_path
+    _installed_bundle = bundle_path
+    logger.info("Trust store extended with extra CAs from %s", extra_path)
+    return bundle_path

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,116 @@
+"""Tests for process-wide trust-store extension (extra CA certificates)."""
+
+import os
+import ssl
+from pathlib import Path
+
+import certifi
+import pytest
+
+from mcp_server_mattermost import tls
+from mcp_server_mattermost.config import Settings
+from mcp_server_mattermost.exceptions import ConfigurationError
+
+
+def _first_pem_cert(bundle_path: str) -> str:
+    """Extract the first certificate PEM block from a bundle."""
+    text = Path(bundle_path).read_text()
+    begin = text.index("-----BEGIN CERTIFICATE-----")
+    end = text.index("-----END CERTIFICATE-----", begin) + len("-----END CERTIFICATE-----")
+    return text[begin:end] + "\n"
+
+
+@pytest.fixture
+def extra_ca_file(tmp_path) -> Path:
+    """A valid single-CA PEM file (first cert of the certifi bundle)."""
+    path = tmp_path / "extra-ca.pem"
+    path.write_text(_first_pem_cert(certifi.where()))
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_tls_state(monkeypatch):
+    """Isolate installed-bundle state and trust-store env vars per test."""
+    monkeypatch.setattr(tls, "_installed_bundle", None)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+
+def _make_settings(monkeypatch, **env: str) -> Settings:
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return Settings()
+
+
+class TestInstallExtraCaCerts:
+    def test_noop_when_unset(self, monkeypatch) -> None:
+        settings = _make_settings(monkeypatch)
+
+        assert tls.install_extra_ca_certs(settings) is None
+        assert "SSL_CERT_FILE" not in os.environ
+
+    def test_builds_combined_bundle(self, monkeypatch, extra_ca_file: Path) -> None:
+        settings = _make_settings(monkeypatch, MATTERMOST_EXTRA_CA_CERTS=str(extra_ca_file))
+
+        bundle_path = tls.install_extra_ca_certs(settings)
+
+        assert bundle_path is not None
+        assert os.environ["SSL_CERT_FILE"] == bundle_path
+        assert os.environ["REQUESTS_CA_BUNDLE"] == bundle_path
+        combined = Path(bundle_path).read_bytes()
+        assert Path(certifi.where()).read_bytes().rstrip() in combined
+        assert extra_ca_file.read_bytes() in combined
+        # combined bundle must be loadable as a trust store
+        ssl.create_default_context().load_verify_locations(cafile=bundle_path)
+
+    def test_uses_existing_ssl_cert_file_as_base(self, monkeypatch, extra_ca_file: Path, tmp_path) -> None:
+        base = tmp_path / "operator-base.pem"
+        base.write_text(_first_pem_cert(certifi.where()))
+        monkeypatch.setenv("SSL_CERT_FILE", str(base))
+        settings = _make_settings(monkeypatch, MATTERMOST_EXTRA_CA_CERTS=str(extra_ca_file))
+
+        bundle_path = tls.install_extra_ca_certs(settings)
+
+        combined = Path(bundle_path).read_bytes()
+        assert base.read_bytes().rstrip() in combined
+        assert extra_ca_file.read_bytes() in combined
+
+    def test_idempotent(self, monkeypatch, extra_ca_file: Path) -> None:
+        settings = _make_settings(monkeypatch, MATTERMOST_EXTRA_CA_CERTS=str(extra_ca_file))
+
+        first = tls.install_extra_ca_certs(settings)
+        second = tls.install_extra_ca_certs(settings)
+
+        assert first == second
+
+    def test_rejects_malformed_pem(self, monkeypatch, tmp_path) -> None:
+        bad = tmp_path / "not-a-cert.pem"
+        bad.write_text("this is not PEM")
+        settings = _make_settings(monkeypatch, MATTERMOST_EXTRA_CA_CERTS=str(bad))
+
+        with pytest.raises(ConfigurationError, match="not a valid PEM"):
+            tls.install_extra_ca_certs(settings)
+
+        assert "SSL_CERT_FILE" not in os.environ
+
+
+class TestExtraCaCertsSetting:
+    def test_missing_file_rejected(self, monkeypatch) -> None:
+        monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+        monkeypatch.setenv("MATTERMOST_EXTRA_CA_CERTS", "/nonexistent/ca.pem")
+
+        with pytest.raises(ValueError, match="file not found"):
+            Settings()
+
+    def test_blank_value_treated_as_unset(self, monkeypatch) -> None:
+        settings = _make_settings(monkeypatch, MATTERMOST_EXTRA_CA_CERTS="  ")
+
+        assert settings.extra_ca_certs is None
+
+    def test_valid_path_accepted(self, monkeypatch, extra_ca_file: Path) -> None:
+        settings = _make_settings(monkeypatch, MATTERMOST_EXTRA_CA_CERTS=str(extra_ca_file))
+
+        assert settings.extra_ca_certs == str(extra_ca_file)

--- a/uv.lock
+++ b/uv.lock
@@ -1163,6 +1163,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
+    { name = "certifi" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -1194,6 +1195,7 @@ docs = [
 requires-dist = [
     { name = "asgi-lifespan", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "cachetools", specifier = ">=5.0" },
+    { name = "certifi" },
     { name = "fastmcp", specifier = ">=3.0.0,<4" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },


### PR DESCRIPTION
## Problem

`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` **replace** the trust store used by httpx and other OpenSSL-based clients rather than extending it. Pointing them at a corporate-CA-only bundle silently breaks TLS to hosts with publicly-signed certificates — in our deployment the OAuth proxy token exchange with the IdP started failing:

```
ERROR IdP token exchange failed: [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: self-signed certificate in certificate chain
```

## Solution

New optional setting `MATTERMOST_EXTRA_CA_CERTS` — path to a PEM file with additional CA certificates (corporate/private CAs) with **append** semantics, analogous to Node's `NODE_EXTRA_CA_CERTS`:

- At server startup the extra CAs are merged with the current default bundle (an operator-provided `SSL_CERT_FILE` or certifi's) into a combined bundle in a temp file.
- `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` are pointed at the combined bundle, so **all** outgoing HTTPS clients pick it up — including fastmcp's OAuth proxy internals — regardless of fastmcp version (works with 3.0.2, which has no client-construction hook).
- Publicly-signed hosts keep working because the default bundle stays in the trust store.

## Changes

- `src/mcp_server_mattermost/tls.py` — `install_extra_ca_certs()`: PEM validation, bundle merge, idempotent install.
- `config.py` — `extra_ca_certs` setting with file-existence validation.
- `server.py` — install hook at server creation, before any HTTP client exists.
- `pyproject.toml` — explicit `certifi` dependency (was transitive via httpx).
- `tests/test_tls.py` — 8 tests: combined bundle contents, operator-base override, idempotency, malformed PEM rejection, settings validation.
- `docs/configuration.md`, `CHANGELOG.md`.

## Verification

- Full suite: 618 passed; ruff / mypy clean.
- Runtime check: generated a test CA, confirmed `ssl.create_default_context(cafile=$SSL_CERT_FILE)` contains it alongside all public CAs and the httpx default client builds against the combined bundle.
