### PR TITLE
Upgrade CodeQL Action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,6 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('trivy-sca.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-sca.sarif

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload Trivy scan results
         if: always() && hashFiles('trivy-*.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-${{ steps.arch.outputs.label }}.sarif
           category: trivy-image-${{ steps.arch.outputs.label }}


### PR DESCRIPTION
## Summary

- Upgrade both `github/codeql-action/upload-sarif` references from v3 to v4.
- Remove the CodeQL Action v3 deprecation warning before its December 2026 deprecation.
- Keep all existing SARIF inputs and upload behavior unchanged.

## Testing

- `uv run ruff check src tests`
- `uv run ruff format src tests`
- `uv run mypy src`
- `uv run pytest` — 618 passed
- Verified no `github/codeql-action/*@v3` references remain in `.github/workflows`.

The SCA SARIF upload runs only on pushes to `main`, and the image SARIF upload runs
only on published releases. Their v4 execution will therefore be exercised by the
corresponding post-merge and release workflows.
