### PR TITLE
ci: add Dependabot config and dependency-update policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 # Requiring Code Owner approval before merge is enforced via branch
 # protection on main (see MAINTAINERS.md).
 
+/.github/CODEOWNERS       @legard
 /.github/dependabot.yml   @legard
 /.github/workflows/       @legard
 /pyproject.toml           @legard

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for dependency, CI, and build files.
+# @legard is auto-requested for review on changes to these paths.
+# Requiring Code Owner approval before merge is enforced via branch
+# protection on main (see MAINTAINERS.md).
+
+/.github/dependabot.yml   @legard
+/.github/workflows/       @legard
+/pyproject.toml           @legard
+/uv.lock                  @legard
+/Dockerfile               @legard

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,21 @@ updates:
       include: "scope"
     cooldown:
       default-days: 3
+
+  # 4) Docs toolchain — docs/requirements.txt (installed by ReadTheDocs)
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+
+updates:
+  # 1) Python dependencies — pyproject.toml + uv.lock
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
+
+  # 2) GitHub Actions — grouped into one PR
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 3
+
+  # 3) Docker base image — separate PRs (single image, no group needed)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    cooldown:
+      default-days: 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,60 @@ Use clear, descriptive commit messages:
 - `test: add tests for file upload`
 - `refactor: simplify channel listing logic`
 
+## Dependency Updates (Dependabot)
+
+Dependencies are kept current by [Dependabot](https://docs.github.com/en/code-security/dependabot),
+configured in `.github/dependabot.yml`. It tracks three ecosystems, each checked
+**weekly** (Monday):
+
+- **Python** (`pyproject.toml` + `uv.lock`)
+- **GitHub Actions** (`.github/workflows/`)
+- **Docker** base image (`Dockerfile`)
+
+A **cooldown** delays PRs until a release has "aged" (Python: patch 3 days, minor
+7 days, major 14 days; Actions/Docker: 3 days), so routine PRs arrive less often
+than weekly and only for releases that have settled. Cooldown does **not** apply
+to security updates — those are raised immediately.
+
+### How PRs are grouped
+
+| Update | Behavior |
+| --- | --- |
+| Python patch + minor | Combined into a single grouped PR (`python-minor-patch`) |
+| Python major | One separate PR per dependency |
+| GitHub Actions | Combined into one grouped PR |
+| Docker base image | Separate PR |
+| Security update | Separate, prioritized PR (never grouped) |
+
+### How PRs are handled
+
+All Dependabot PRs run the full CI (unit tests on Python 3.10–3.13, `ruff`,
+`mypy`, Trivy SCA, integration tests) and are **merged manually** by a maintainer
+after CI is green — there is no auto-merge.
+
+- **Patch / minor (grouped):** confirm CI is green, skim the changelogs, merge.
+- **Major:** review the migration guide and breaking changes, update code if
+  needed, confirm full CI, then merge.
+- **Security:** review with priority, confirm CI, merge promptly, and release a
+  fixed version.
+
+### Unmerged PRs
+
+Dependabot does **not** create duplicates on the next weekly run. It updates the
+existing open PR in place — bumping a grouped PR to include newly available
+patches, moving a PR to a newer version if one is released, or rebasing after
+`main` moves. Once an ecosystem reaches its open-PR limit (Python 5, Actions 3,
+Docker 3), no new PRs are opened until some are merged or closed. **Do not push
+commits into a Dependabot PR branch** unless you intend to take it over —
+manual edits stop Dependabot from auto-updating that PR.
+
+### Library compatibility
+
+This package is published to PyPI with intentionally broad version ranges (e.g.
+`fastmcp>=3.4,<4`). Do **not** raise a dependency's minimum version without a
+concrete reason — it forces downstream users to upgrade. Treat any PR that lifts
+a lower bound as potentially breaking, and note the reason in the changelog.
+
 ## Questions?
 
 Open an issue if you have questions or need help getting started.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,16 @@ Use clear, descriptive commit messages:
 ## Dependency Updates (Dependabot)
 
 Dependencies are kept current by [Dependabot](https://docs.github.com/en/code-security/dependabot),
-configured in `.github/dependabot.yml`. It tracks three ecosystems, each checked
-**weekly** (Monday):
+configured in `.github/dependabot.yml`. It tracks four package ecosystems, each
+checked **weekly** (Monday):
 
 - **Python** (`pyproject.toml` + `uv.lock`)
 - **GitHub Actions** (`.github/workflows/`)
 - **Docker** base image (`Dockerfile`)
+- **Docs toolchain** (`docs/requirements.txt`, used by ReadTheDocs)
 
 A **cooldown** delays PRs until a release has "aged" (Python: patch 3 days, minor
-7 days, major 14 days; Actions/Docker: 3 days), so routine PRs arrive less often
+7 days, major 14 days; Actions/Docker/docs: 3 days), so routine PRs arrive less often
 than weekly and only for releases that have settled. Cooldown does **not** apply
 to security updates — those are raised immediately.
 
@@ -86,6 +87,7 @@ to security updates — those are raised immediately.
 | Python major | One separate PR per dependency |
 | GitHub Actions | Combined into one grouped PR |
 | Docker base image | Separate PR |
+| Docs toolchain (pip) | Separate PR |
 | Security update | Separate, prioritized PR (never grouped) |
 
 ### How PRs are handled
@@ -106,7 +108,7 @@ Dependabot does **not** create duplicates on the next weekly run. It updates the
 existing open PR in place — bumping a grouped PR to include newly available
 patches, moving a PR to a newer version if one is released, or rebasing after
 `main` moves. Once an ecosystem reaches its open-PR limit (Python 5, Actions 3,
-Docker 3), no new PRs are opened until some are merged or closed. **Do not push
+Docker 3, docs 2), no new PRs are opened until some are merged or closed. **Do not push
 commits into a Dependabot PR branch** unless you intend to take it over —
 manual edits stop Dependabot from auto-updating that PR.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -92,6 +92,6 @@ JSON
 After the config is merged to `main`:
 
 1. Go to the repository's **Insights → Dependency graph → Dependabot** tab.
-2. Each ecosystem (`uv`, `github-actions`, `docker`) should be listed with a
-   recent "last checked" time and **no config error**.
+2. Each ecosystem (`uv`, `github-actions`, `docker`, `pip`) should be listed
+   with a recent "last checked" time and **no config error**.
 3. Use **"Check for updates"** to trigger a run on demand.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,7 +84,8 @@ JSON
 - Dependabot PRs already run with a read-only `GITHUB_TOKEN` and have **no**
   access to Actions secrets — this is the correct, safe default.
 - Publish workflows (`publish.yml`, `docker-publish.yml`) trigger only on
-  `release: published`, so they never run on a Dependabot PR.
+  `release: published`, and `publish-test.yml` only on manual
+  `workflow_dispatch` — none of them ever run on a Dependabot PR.
 - No workflow uses `pull_request_target`; keep it that way.
 
 ## Verifying the Dependabot config

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,97 @@
+# Maintainers Guide
+
+Admin tasks for repository maintainers. These are GitHub **repository settings**
+that cannot be committed as files; apply them via the GitHub UI or `gh` CLI
+(requires admin permission on `cloud-ru-tech/mcp-server-mattermost`).
+
+## Dependabot: required repository settings
+
+The scheduled updates live in `.github/dependabot.yml`. The following must be
+enabled once, in the repository settings, to complete the setup.
+
+### 1. Security features
+
+**UI:** Settings → Advanced Security (Code security) → enable:
+
+- **Dependency graph** (on by default for public repos)
+- **Dependabot alerts**
+- **Dependabot security updates**
+
+**CLI equivalent:**
+
+```bash
+# Dependabot alerts
+gh api -X PUT repos/cloud-ru-tech/mcp-server-mattermost/vulnerability-alerts
+
+# Dependabot security updates (automated security fix PRs)
+gh api -X PUT repos/cloud-ru-tech/mcp-server-mattermost/automated-security-fixes
+```
+
+Security-update PRs are raised independently of the weekly schedule and are not
+delayed by cooldown.
+
+### 2. Branch protection on `main`
+
+Dependabot PRs must not bypass CI. Require all checks and a Code Owner review
+before merge.
+
+**UI:** Settings → Branches → Add branch ruleset (or classic protection) for
+`main`:
+
+- Require a pull request before merging
+- Require status checks to pass — select: `test (3.10)`, `test (3.11)`,
+  `test (3.12)`, `test (3.13)`, `sca`, `integration-tests`
+- Require branches to be up to date before merging
+- Require review from Code Owners
+- Do not allow direct pushes / bypassing
+
+**CLI equivalent (classic branch protection):**
+
+```bash
+gh api -X PUT repos/cloud-ru-tech/mcp-server-mattermost/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "test (3.10)",
+      "test (3.11)",
+      "test (3.12)",
+      "test (3.13)",
+      "sca",
+      "integration-tests"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null
+}
+JSON
+```
+
+> Check names come from the job names in `.github/workflows/ci.yml`
+> (`test` matrix + `sca`) and `integration-tests.yml`. Confirm the exact
+> strings on a real PR's checks list before locking them in — a typo makes a
+> check "required" that never reports, blocking all merges.
+
+### 3. Secrets — do not grant Dependabot production access
+
+- Do **not** add any secrets under Settings → Secrets and variables →
+  **Dependabot**. This project's workflows need none for PR validation.
+- Dependabot PRs already run with a read-only `GITHUB_TOKEN` and have **no**
+  access to Actions secrets — this is the correct, safe default.
+- Publish workflows (`publish.yml`, `docker-publish.yml`) trigger only on
+  `release: published`, so they never run on a Dependabot PR.
+- No workflow uses `pull_request_target`; keep it that way.
+
+## Verifying the Dependabot config
+
+After the config is merged to `main`:
+
+1. Go to the repository's **Insights → Dependency graph → Dependabot** tab.
+2. Each ecosystem (`uv`, `github-actions`, `docker`) should be listed with a
+   recent "last checked" time and **no config error**.
+3. Use **"Check for updates"** to trigger a run on demand.


### PR DESCRIPTION
## Summary

Sets up scheduled dependency updates via Dependabot and documents the policy.

- **`.github/dependabot.yml`** — four update entries: `uv` (pyproject + uv.lock), `github-actions`, `docker`, and `pip` for `docs/requirements.txt` (used by ReadTheDocs). Weekly Monday checks (staggered), tiered cooldown (Python: patch 3d / minor 7d / major 14d; others 3d), per-ecosystem open-PR limits.
- **Grouping:** Python patch+minor in one grouped PR, majors separate, Actions grouped, Docker and docs separate. Security updates are never grouped and skip cooldown.
- **`.github/CODEOWNERS`** — auto-requests review on dependency/CI/build files (and owns itself).
- **`CONTRIBUTING.md`** — contributor-facing policy: how Dependabot PRs are grouped and handled; fully manual, CI-gated merges (no auto-merge); do not raise library lower bounds without cause.
- **`MAINTAINERS.md`** — admin runbook for settings that cannot be committed: Dependabot alerts + security updates, branch protection on `main` (required checks + Code Owner review), and secrets guidance (no Dependabot secrets; read-only `GITHUB_TOKEN`; no `pull_request_target`).

## Notes for reviewers

- `versioning-strategy: increase-if-necessary` on the `uv` block preserves the library's broad PyPI ranges — the manifest is only touched when a release falls outside the existing range. Support for this key in the `uv` ecosystem is confirmed (GitHub docs list `uv` among supported ecosystems; dependabot-core's uv updater reuses the Python requirements updater). The deliberate alternative rejects: `auto` relies on fragile PyPI-metadata library detection, `lockfile-only` would never surface out-of-range (major) updates.
- Repository settings from MAINTAINERS.md must be applied after merge.