### PR TITLE
ci: switch Dependabot to monthly update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "09:00"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 5
@@ -34,8 +33,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "09:30"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 3
@@ -57,8 +55,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "10:00"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 3
@@ -75,8 +72,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "10:30"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Use clear, descriptive commit messages:
 
 Dependencies are kept current by [Dependabot](https://docs.github.com/en/code-security/dependabot),
 configured in `.github/dependabot.yml`. It tracks four package ecosystems, each
-checked **weekly** (Monday):
+checked **monthly**:
 
 - **Python** (`pyproject.toml` + `uv.lock`)
 - **GitHub Actions** (`.github/workflows/`)
@@ -75,8 +75,8 @@ checked **weekly** (Monday):
 - **Docs toolchain** (`docs/requirements.txt`, used by ReadTheDocs)
 
 A **cooldown** delays PRs until a release has "aged" (Python: patch 3 days, minor
-7 days, major 14 days; Actions/Docker/docs: 3 days), so routine PRs arrive less often
-than weekly and only for releases that have settled. Cooldown does **not** apply
+7 days, major 14 days; Actions/Docker/docs: 3 days), so routine PRs arrive at most
+monthly and only for releases that have settled. Cooldown does **not** apply
 to security updates — those are raised immediately.
 
 ### How PRs are grouped
@@ -104,7 +104,7 @@ after CI is green — there is no auto-merge.
 
 ### Unmerged PRs
 
-Dependabot does **not** create duplicates on the next weekly run. It updates the
+Dependabot does **not** create duplicates on the next monthly run. It updates the
 existing open PR in place — bumping a grouped PR to include newly available
 patches, moving a PR to a newer version if one is released, or rebasing after
 `main` moves. Once an ecosystem reaches its open-PR limit (Python 5, Actions 3,

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -27,7 +27,7 @@ gh api -X PUT repos/cloud-ru-tech/mcp-server-mattermost/vulnerability-alerts
 gh api -X PUT repos/cloud-ru-tech/mcp-server-mattermost/automated-security-fixes
 ```
 
-Security-update PRs are raised independently of the weekly schedule and are not
+Security-update PRs are raised independently of the monthly schedule and are not
 delayed by cooldown.
 
 ### 2. Branch protection on `main`


### PR DESCRIPTION
## Summary

Moves all four Dependabot ecosystems (uv, github-actions, docker, pip-docs) from
a weekly to a monthly schedule. Weekly checks produced routine PRs as often as
every week; a monthly cadence keeps routine dependency review to roughly once a
month. Dependabot has no native fortnightly interval, so monthly is the closest
native fit. The `day` field (weekly-only) is removed; staggered times, cooldown,
grouping, and per-ecosystem limits are unchanged.

## Security note

High-severity vulnerabilities are **not** slowed by this: they arrive
out-of-band via Dependabot **security updates**, which ignore the schedule and
cooldown. That feature must be enabled in repo settings (see MAINTAINERS.md §1)
— it will be turned on right after this merges.