### PR TITLE
feat: HTTP transport security — static_token warning and opt-in DNS-rebinding protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ demo/
 # MkDocs build output
 site/
 .specs/
+
+# Dogfooding run artifacts (reports, logs, screenshots, videos)
+dogfood-output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,6 @@ Optional:
 - `MATTERMOST_LOG_FORMAT` (default: json) - Log format: 'json' for production, 'text' for development
 - `MATTERMOST_API_VERSION` (default: v4)
 - `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` (default: false) - Allow HTTP clients to use their own Mattermost tokens
-- `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP` (default: false) - Allow `static_token` over HTTP on loopback only (unauthenticated MCP endpoint)
 - `MATTERMOST_HTTP_ALLOWED_HOSTS` (default: none) - Extra allowed `Host` header values for HTTP transport (JSON array or comma-separated)
 - `MATTERMOST_HTTP_ALLOWED_ORIGINS` (default: none) - Extra allowed `Origin` header values for HTTP transport (JSON array or comma-separated)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,9 @@ Optional:
 - `MATTERMOST_LOG_FORMAT` (default: json) - Log format: 'json' for production, 'text' for development
 - `MATTERMOST_API_VERSION` (default: v4)
 - `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` (default: false) - Allow HTTP clients to use their own Mattermost tokens
+- `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP` (default: false) - Allow `static_token` over HTTP on loopback only (unauthenticated MCP endpoint)
+- `MATTERMOST_HTTP_ALLOWED_HOSTS` (default: none) - Extra allowed `Host` header values for HTTP transport (JSON array or comma-separated)
+- `MATTERMOST_HTTP_ALLOWED_ORIGINS` (default: none) - Extra allowed `Origin` header values for HTTP transport (JSON array or comma-separated)
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,9 @@ Optional:
 - `MATTERMOST_LOG_FORMAT` (default: json) - Log format: 'json' for production, 'text' for development
 - `MATTERMOST_API_VERSION` (default: v4)
 - `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` (default: false) - Allow HTTP clients to use their own Mattermost tokens
-- `MATTERMOST_HTTP_ALLOWED_HOSTS` (default: none) - Extra allowed `Host` header values for HTTP transport (JSON array or comma-separated)
-- `MATTERMOST_HTTP_ALLOWED_ORIGINS` (default: none) - Extra allowed `Origin` header values for HTTP transport (JSON array or comma-separated)
+- `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` (default: none) - Host/Origin protection: `off`, `auto`, or `strict`
+- `MATTERMOST_HTTP_ALLOWED_HOSTS` (default: none) - Extra allowed `Host` header values (JSON array or comma-separated)
+- `MATTERMOST_HTTP_ALLOWED_ORIGINS` (default: none) - Extra allowed `Origin` header values (JSON array or comma-separated)
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,18 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (amd64, arm64) is built and scanned before the manifest is pushed (fails on
   fixable HIGH/CRITICAL). Exceptions only via `.trivyignore` with a documented
   reason and review date.
-- HTTP transport now refuses to start with `MATTERMOST_AUTH_MODE=static_token` (the default) unless bound to
-  loopback with `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true`; a non-loopback bind with `static_token` is always
-  refused. This prevents accidentally exposing an unauthenticated MCP endpoint that acts with the shared
-  Mattermost token. Use `client_token` or `oauth_proxy` for networked HTTP.
+- HTTP transport with `MATTERMOST_AUTH_MODE=static_token` (the default) now logs a security warning at
+  startup instead of refusing — a plain warning on a loopback bind, a louder one on a non-loopback bind
+  (`0.0.0.0`) where the unauthenticated endpoint (acting with the shared Mattermost token) is reachable by
+  network peers. The server never fails to start on this account, so container upgrades are not broken; put
+  an authenticating proxy in front, or use `client_token` / `oauth_proxy`, for networked HTTP.
 - Enabled DNS-rebinding protection for the HTTP transport (`host_origin_protection="auto"`): loopback
   deployments reject unknown `Host`/`Origin` headers. New `MATTERMOST_HTTP_ALLOWED_HOSTS` /
   `MATTERMOST_HTTP_ALLOWED_ORIGINS` declare allowlists for networked deployments.
-
-### Changed
-- **Breaking (HTTP only):** the previous `docker run` HTTP example (`static_token` bound to `0.0.0.0`) no
-  longer starts. Switch to `MATTERMOST_AUTH_MODE=client_token`/`oauth_proxy`, or bind to loopback behind a
-  co-located auth proxy. stdio `static_token` is unchanged.
 
 ## [0.5.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (amd64, arm64) is built and scanned before the manifest is pushed (fails on
   fixable HIGH/CRITICAL). Exceptions only via `.trivyignore` with a documented
   reason and review date.
+- HTTP transport now refuses to start with `MATTERMOST_AUTH_MODE=static_token` (the default) unless bound to
+  loopback with `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true`; a non-loopback bind with `static_token` is always
+  refused. This prevents accidentally exposing an unauthenticated MCP endpoint that acts with the shared
+  Mattermost token. Use `client_token` or `oauth_proxy` for networked HTTP.
+- Enabled DNS-rebinding protection for the HTTP transport (`host_origin_protection="auto"`): loopback
+  deployments reject unknown `Host`/`Origin` headers. New `MATTERMOST_HTTP_ALLOWED_HOSTS` /
+  `MATTERMOST_HTTP_ALLOWED_ORIGINS` declare allowlists for networked deployments.
+
+### Changed
+- **Breaking (HTTP only):** the previous `docker run` HTTP example (`static_token` bound to `0.0.0.0`) no
+  longer starts. Switch to `MATTERMOST_AUTH_MODE=client_token`/`oauth_proxy`, or bind to loopback behind a
+  co-located auth proxy. stdio `static_token` is unchanged.
 
 ## [0.5.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   missing consent check in the OAuth proxy callback), plus CVE-2026-32871
   (authenticated SSRF) and CVE-2025-64340 (command injection) that were
   present in the previous 3.0.2, and includes later redirect-URI/SSRF/
-  DNS-rebinding hardening; dependency floor raised to `fastmcp>=3.4,<4`.
+  DNS-rebinding hardening; dependency floor raised to `fastmcp>=3.4.4,<4`
+  (3.4.3 is the first release with the Host/Origin protection kwargs the HTTP
+  transport passes unconditionally; 3.4.4 is the tested/locked version).
 - Remediated 20 known advisories (8 HIGH, 9 MEDIUM, 3 LOW) in transitive and
   dev/docs dependencies by upgrading them to fixed versions: `cryptography`,
   `pyjwt`, `mcp`, `urllib3`, `pydantic-settings`, `requests`, `idna`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,61 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
-- Upgraded FastMCP to 3.4.4 — fixes CVE-2026-27124 (GHSA-rww4-4w9c-7733,
-  missing consent check in the OAuth proxy callback), plus CVE-2026-32871
-  (authenticated SSRF) and CVE-2025-64340 (command injection) that were
-  present in the previous 3.0.2, and includes later redirect-URI/SSRF/
-  DNS-rebinding hardening; dependency floor raised to `fastmcp>=3.4.4,<4`
-  (3.4.3 is the first release with the Host/Origin protection kwargs the HTTP
-  transport passes unconditionally; 3.4.4 is the tested/locked version).
-- Remediated 20 known advisories (8 HIGH, 9 MEDIUM, 3 LOW) in transitive and
-  dev/docs dependencies by upgrading them to fixed versions: `cryptography`,
-  `pyjwt`, `mcp`, `urllib3`, `pydantic-settings`, `requests`, `idna`,
-  `pytest`, `pygments`, `pymdown-extensions`.
-- Added a blocking SCA gate: Trivy scans `uv.lock` on every PR and push to
-  main and fails on *fixable* HIGH/CRITICAL vulnerabilities, matching the
-  per-architecture image scan. Fixable LOW/MEDIUM are reported (CI log, plus
-  the Security tab on main) but do not block; vulnerabilities with no fix
-  available are reported but never block. Every published image architecture
-  (amd64, arm64) is built and scanned before the manifest is pushed (fails on
-  fixable HIGH/CRITICAL). Exceptions only via `.trivyignore` with a documented
-  reason and review date.
-- HTTP transport with `MATTERMOST_AUTH_MODE=static_token` (the default) now logs a security warning at
-  startup instead of refusing — a plain warning on a loopback bind, a louder one on a non-loopback bind
-  (`0.0.0.0`) where the unauthenticated endpoint (acting with the shared Mattermost token) is reachable by
-  network peers. The server never fails to start on this account, so container upgrades are not broken; put
-  an authenticating proxy in front, or use `client_token` / `oauth_proxy`, for networked HTTP.
-- Added opt-in DNS-rebinding protection for the HTTP transport via
-  `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` (`off` / `auto` / `strict`). It is **off unless set**, so
-  upgrading does not start rejecting traffic that worked before; leaving it unset also keeps FastMCP's
-  own `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` in effect. Under `auto` each connection is validated by the
-  local address it arrives on: an arrival on `127.0.0.1`/`localhost`/`::1` rejects an unknown `Host`
-  (`421`) and a foreign `Origin` (`403`) even when the server is bound to `0.0.0.0`, while arrivals on a
-  LAN or public address are validated once `MATTERMOST_HTTP_ALLOWED_HOSTS` /
-  `MATTERMOST_HTTP_ALLOWED_ORIGINS` declares an allowlist. On a loopback bind FastMCP adds the bind
-  address to the allowlist, so a reverse proxy forwarding a public `Host` must be listed there — see
+- Upgraded FastMCP to 3.4.4 — fixes CVE-2026-27124 (GHSA-rww4-4w9c-7733, missing consent check in the
+  OAuth proxy callback), plus CVE-2026-32871 (authenticated SSRF) and CVE-2025-64340 (command injection)
+  present in the previous 3.0.2. Floor raised to `fastmcp>=3.4.4,<4`; 3.4.3 is the first release with the
+  Host/Origin protection this transport relies on.
+- Remediated 20 known advisories (8 HIGH, 9 MEDIUM, 3 LOW) in transitive and dev/docs dependencies:
+  `cryptography`, `pyjwt`, `mcp`, `urllib3`, `pydantic-settings`, `requests`, `idna`, `pytest`,
+  `pygments`, `pymdown-extensions`.
+- Added a blocking SCA gate: Trivy scans `uv.lock` and every published image architecture, failing on
+  *fixable* HIGH/CRITICAL. Fixable LOW/MEDIUM are reported but do not block, as are vulnerabilities with
+  no fix available. Exceptions only via `.trivyignore` with a documented reason and review date.
+- `static_token` over HTTP now warns at startup instead of refusing to start — louder on a non-loopback
+  bind, where the unauthenticated endpoint acting with the shared token is reachable by network peers.
+  Container upgrades are no longer broken by this check.
+- Added opt-in DNS-rebinding protection via `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION`
+  (`off` / `auto` / `strict`), with `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS`
+  allowlists. **Off unless set**, so upgrading rejects nothing that worked before, and FastMCP's own
+  `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` still applies. Configured through FastMCP's settings rather than
+  `mcp.run()` kwargs, so it also covers `fastmcp run`, a standalone ASGI server, and the app mounted into
+  a parent application — previously none of those were protected. Rejections are logged with the
+  offending `Host`/`Origin` and the variable that would accept it. See
   [HTTP transport security](docs/configuration.md#http-transport-security).
-- The protection is applied through FastMCP's settings rather than passed to `mcp.run()`, so it now also
-  covers `fastmcp run`, a standalone ASGI server over `mcp.http_app()`, and this app mounted into a
-  parent Starlette/FastAPI application — previously none of those received it.
-- Rejections are logged at `WARNING` naming the offending `Host`/`Origin`, the address the connection
-  arrived on, and the variable that would accept it; the response stays a bare `421`/`403`. The HTTP
-  transport logs the active posture and the configured allowlists at startup, and warns when an
-  allowlist is configured while protection is off.
 
 ### Deprecated
-- Host/Origin protection defaults to off. **Starting with 1.0.0 the default becomes `auto`**, which
-  rejects an unknown `Host` with `421` on connections arriving over loopback — including a same-host
-  reverse proxy or health checker that forwards a public `Host`. Set
-  `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` explicitly now — including `=off` if that is the behavior you
-  want — and the upgrade changes nothing for you. See
-  [HTTP transport security](docs/configuration.md#http-transport-security).
+- Host/Origin protection defaults to off; **in 1.0.0 the default becomes `auto`** (#30). Set
+  `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` explicitly now — `=off` included — and that upgrade changes
+  nothing for you.
 
 ### Fixed
-- `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` accept bracketed IPv6 literals
-  (`[::1]`, `[::1],127.0.0.1`), which previously aborted startup with a JSON parser error. Values that
-  reduce to an empty list (`[]`, a stray trailing comma) are now treated as unset instead of as an
-  allowlist matching nothing.
+- Allowlists accept bracketed IPv6 literals (`[::1]`), which previously aborted startup with a JSON
+  parser error; a value reducing to an empty list is now treated as unset rather than as an allowlist
+  matching nothing.
 - Raised the `pydantic-settings` floor to `>=2.7`. The declared `>=2.0` allowed versions without
   `NoDecode`, where the package failed to import at all — on stdio as well as HTTP.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,14 +32,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`0.0.0.0`) where the unauthenticated endpoint (acting with the shared Mattermost token) is reachable by
   network peers. The server never fails to start on this account, so container upgrades are not broken; put
   an authenticating proxy in front, or use `client_token` / `oauth_proxy`, for networked HTTP.
-- Enabled DNS-rebinding protection for the HTTP transport (`host_origin_protection="auto"`): each connection
-  is validated by the local address it arrives on, so a request arriving on `127.0.0.1`/`localhost`/`::1`
-  rejects an unknown `Host` (`421`) and a foreign `Origin` (`403`) even when the server is bound to `0.0.0.0`.
-  Arrivals on a LAN or public address are validated once `MATTERMOST_HTTP_ALLOWED_HOSTS` /
-  `MATTERMOST_HTTP_ALLOWED_ORIGINS` declares an allowlist. A same-host reverse proxy or health checker that
-  reaches the server over loopback with a public `Host`/`Origin` must be listed there — see
-  [HTTP transport security](docs/configuration.md#http-transport-security). The HTTP transport logs the
-  active posture and the configured allowlists at startup.
+- Added opt-in DNS-rebinding protection for the HTTP transport via
+  `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` (`off` / `auto` / `strict`). It is **off unless set**, so
+  upgrading does not start rejecting traffic that worked before; leaving it unset also keeps FastMCP's
+  own `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` in effect. Under `auto` each connection is validated by the
+  local address it arrives on: an arrival on `127.0.0.1`/`localhost`/`::1` rejects an unknown `Host`
+  (`421`) and a foreign `Origin` (`403`) even when the server is bound to `0.0.0.0`, while arrivals on a
+  LAN or public address are validated once `MATTERMOST_HTTP_ALLOWED_HOSTS` /
+  `MATTERMOST_HTTP_ALLOWED_ORIGINS` declares an allowlist. On a loopback bind FastMCP adds the bind
+  address to the allowlist, so a reverse proxy forwarding a public `Host` must be listed there — see
+  [HTTP transport security](docs/configuration.md#http-transport-security).
+- The protection is applied through FastMCP's settings rather than passed to `mcp.run()`, so it now also
+  covers `fastmcp run`, a standalone ASGI server over `mcp.http_app()`, and this app mounted into a
+  parent Starlette/FastAPI application — previously none of those received it.
+- Rejections are logged at `WARNING` naming the offending `Host`/`Origin`, the address the connection
+  arrived on, and the variable that would accept it; the response stays a bare `421`/`403`. The HTTP
+  transport logs the active posture and the configured allowlists at startup, and warns when an
+  allowlist is configured while protection is off.
+
+### Deprecated
+- Host/Origin protection defaults to off. **Starting with 1.0.0 the default becomes `auto`**, which
+  rejects an unknown `Host` with `421` on connections arriving over loopback — including a same-host
+  reverse proxy or health checker that forwards a public `Host`. Set
+  `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` explicitly now — including `=off` if that is the behavior you
+  want — and the upgrade changes nothing for you. See
+  [HTTP transport security](docs/configuration.md#http-transport-security).
+
+### Fixed
+- `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` accept bracketed IPv6 literals
+  (`[::1]`, `[::1],127.0.0.1`), which previously aborted startup with a JSON parser error. Values that
+  reduce to an empty list (`[]`, a stray trailing comma) are now treated as unset instead of as an
+  allowlist matching nothing.
+- Raised the `pydantic-settings` floor to `>=2.7`. The declared `>=2.0` allowed versions without
+  `NoDecode`, where the package failed to import at all — on stdio as well as HTTP.
 
 ## [0.5.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`0.0.0.0`) where the unauthenticated endpoint (acting with the shared Mattermost token) is reachable by
   network peers. The server never fails to start on this account, so container upgrades are not broken; put
   an authenticating proxy in front, or use `client_token` / `oauth_proxy`, for networked HTTP.
-- Enabled DNS-rebinding protection for the HTTP transport (`host_origin_protection="auto"`): loopback
-  deployments reject unknown `Host`/`Origin` headers. New `MATTERMOST_HTTP_ALLOWED_HOSTS` /
-  `MATTERMOST_HTTP_ALLOWED_ORIGINS` declare allowlists for networked deployments.
+- Enabled DNS-rebinding protection for the HTTP transport (`host_origin_protection="auto"`): each connection
+  is validated by the local address it arrives on, so a request arriving on `127.0.0.1`/`localhost`/`::1`
+  rejects an unknown `Host` (`421`) and a foreign `Origin` (`403`) even when the server is bound to `0.0.0.0`.
+  Arrivals on a LAN or public address are validated once `MATTERMOST_HTTP_ALLOWED_HOSTS` /
+  `MATTERMOST_HTTP_ALLOWED_ORIGINS` declares an allowlist. A same-host reverse proxy or health checker that
+  reaches the server over loopback with a public `Host`/`Origin` must be listed there — see
+  [HTTP transport security](docs/configuration.md#http-transport-security). The HTTP transport logs the
+  active posture and the configured allowlists at startup.
 
 ## [0.5.1] - 2026-07-07
 

--- a/README.md
+++ b/README.md
@@ -216,12 +216,16 @@ docker run -i --rm \
 
 ### HTTP mode (production)
 
+For networked HTTP use per-client auth. `static_token` over HTTP serves an unauthenticated endpoint acting
+with the shared token (the server starts but logs a loud warning) — see
+[HTTP transport security](docs/configuration.md#http-transport-security).
+
 ```bash
 docker run -d -p 8000:8000 \
   -e MCP_TRANSPORT=http \
   -e MCP_HOST=0.0.0.0 \
+  -e MATTERMOST_AUTH_MODE=client_token \
   -e MATTERMOST_URL=https://your-mattermost.com \
-  -e MATTERMOST_TOKEN=your-token \
   legard/mcp-server-mattermost
 ```
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ docker run -i --rm \
 
 For networked HTTP use per-client auth. `static_token` over HTTP serves an unauthenticated endpoint acting
 with the shared token (the server starts but logs a loud warning) — see
-[HTTP transport security](docs/configuration.md#http-transport-security).
+[Authentication → HTTP transport](docs/authentication.md#http-transport).
 
 ```bash
 docker run -d -p 8000:8000 \

--- a/README.md
+++ b/README.md
@@ -226,8 +226,15 @@ docker run -d -p 8000:8000 \
   -e MCP_HOST=0.0.0.0 \
   -e MATTERMOST_AUTH_MODE=client_token \
   -e MATTERMOST_URL=https://your-mattermost.com \
+  -e MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION=auto \
+  -e MATTERMOST_HTTP_ALLOWED_HOSTS=mcp.example.com \
   legard/mcp-server-mattermost
 ```
+
+`client_token` means each MCP client authenticates with its own Mattermost token, sent as
+`Authorization: Bearer <token>` — a client configured without one gets `401`. The two
+`MATTERMOST_HTTP_*` variables turn on Host/Origin (DNS-rebinding) protection, which is off by
+default; see [HTTP transport security](docs/configuration.md#http-transport-security).
 
 Health check: `curl http://localhost:8000/health`
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -47,16 +47,17 @@ the user's permissions.
 
 ### HTTP transport
 
-`static_token` over HTTP publishes an **unauthenticated** endpoint that acts with the shared token, so it
-is refused by default. It is allowed only on a loopback bind with an explicit opt-in:
+`static_token` over HTTP publishes an **unauthenticated** endpoint that acts with the shared token. The
+server always starts and logs a security warning — a plain one on a loopback bind, a louder one on a
+non-loopback bind (`0.0.0.0`), where any peer that can reach the address can drive the tools with the
+token's privileges:
 
 ```bash
 export MCP_TRANSPORT=http MCP_HOST=127.0.0.1
-export MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true
 ```
 
-Binding to a non-loopback address (e.g. `0.0.0.0`) with `static_token` is always refused. For networked or
-multi-user HTTP, use [`client_token`](#client_token) or [`oauth_proxy`](#oauth_proxy).
+For a non-loopback bind, put an authenticating reverse proxy in front, or — for networked or multi-user
+HTTP — use [`client_token`](#client_token) or [`oauth_proxy`](#oauth_proxy) so each client authenticates.
 
 ## `client_token`
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -45,6 +45,19 @@ The token needs these Mattermost permissions for full functionality:
 Bot accounts get most permissions automatically. Personal access tokens inherit
 the user's permissions.
 
+### HTTP transport
+
+`static_token` over HTTP publishes an **unauthenticated** endpoint that acts with the shared token, so it
+is refused by default. It is allowed only on a loopback bind with an explicit opt-in:
+
+```bash
+export MCP_TRANSPORT=http MCP_HOST=127.0.0.1
+export MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true
+```
+
+Binding to a non-loopback address (e.g. `0.0.0.0`) with `static_token` is always refused. For networked or
+multi-user HTTP, use [`client_token`](#client_token) or [`oauth_proxy`](#oauth_proxy).
+
 ## `client_token`
 
 HTTP transport mode where each MCP client sends its own Mattermost token. The

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -59,6 +59,10 @@ export MCP_TRANSPORT=http MCP_HOST=127.0.0.1
 For a non-loopback bind, put an authenticating reverse proxy in front, or — for networked or multi-user
 HTTP — use [`client_token`](#client_token) or [`oauth_proxy`](#oauth_proxy) so each client authenticates.
 
+Independently of the auth mode, the HTTP transport enables Host/Origin DNS-rebinding protection. See
+[HTTP transport security](configuration.md#http-transport-security) for the
+`MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` allowlists and `421`/`403` troubleshooting.
+
 ## `client_token`
 
 HTTP transport mode where each MCP client sends its own Mattermost token. The

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -59,8 +59,9 @@ export MCP_TRANSPORT=http MCP_HOST=127.0.0.1
 For a non-loopback bind, put an authenticating reverse proxy in front, or — for networked or multi-user
 HTTP — use [`client_token`](#client_token) or [`oauth_proxy`](#oauth_proxy) so each client authenticates.
 
-Independently of the auth mode, the HTTP transport enables Host/Origin DNS-rebinding protection. See
-[HTTP transport security](configuration.md#http-transport-security) for the
+Independently of the auth mode, the HTTP transport offers Host/Origin DNS-rebinding protection, off until
+`MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` turns it on. See
+[HTTP transport security](configuration.md#http-transport-security) for that setting, the
 `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` allowlists and `421`/`403` troubleshooting.
 
 ## `client_token`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,9 +27,10 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 
 ## HTTP transport security
 
-`static_token` over HTTP is never blocked, but it serves an unauthenticated endpoint acting with the shared
-token — the server logs a warning at startup (louder on a non-loopback bind). For networked access, front it
-with an authenticating proxy or use `client_token` / `oauth_proxy` (see [Authentication](authentication.md)).
+`static_token` over HTTP serves an unauthenticated endpoint acting with the shared token — the server warns
+but never blocks. See [Authentication → HTTP transport](authentication.md#http-transport) for that auth
+posture and its remediation. This section covers the transport-level Host/Origin protection, which applies
+to every auth mode.
 
 The HTTP transport turns on DNS-rebinding protection automatically (`host_origin_protection="auto"`):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,17 +22,27 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |
-| `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP` | false | Allow `static_token` over HTTP — loopback bind only. See [Authentication](authentication.md#static_token) |
 | `MATTERMOST_HTTP_ALLOWED_HOSTS` | — | Extra allowed `Host` values for HTTP (JSON array or comma-separated) |
 | `MATTERMOST_HTTP_ALLOWED_ORIGINS` | — | Extra allowed `Origin` values for HTTP (JSON array or comma-separated) |
 
 ## HTTP transport security
 
-The HTTP transport enables DNS-rebinding protection automatically (`host_origin_protection="auto"`):
-loopback deployments reject unknown `Host`/`Origin` headers, while non-loopback binds are unaffected
-until you declare an allowlist. Set `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS`
-to enforce strict validation for a networked deployment (e.g. the public host behind a reverse proxy).
-`X-Forwarded-*` headers are not trusted automatically.
+`static_token` over HTTP is never blocked, but it serves an unauthenticated endpoint acting with the shared
+token — the server logs a warning at startup (louder on a non-loopback bind). For networked access, front it
+with an authenticating proxy or use `client_token` / `oauth_proxy` (see [Authentication](authentication.md)).
+
+The HTTP transport turns on DNS-rebinding protection automatically (`host_origin_protection="auto"`):
+
+- **Loopback bind** (`127.0.0.1` / `localhost` / `::1`) — `Host` and `Origin` are validated. Normal MCP
+  clients (loopback `Host`, no `Origin`) pass; an unknown `Host` gets `421`, a foreign `Origin` gets `403`.
+- **Non-loopback bind** (`0.0.0.0`, LAN IP) — validation is **off** until you set an allowlist, so it does
+  not protect a networked deployment on its own.
+
+Declare allowlists with `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` (JSON array or
+comma-separated) — e.g. the public host behind a reverse proxy. `X-Forwarded-*` headers are not trusted.
+
+**Troubleshooting:** `421 Misdirected Request` → add the client's `Host` to `MATTERMOST_HTTP_ALLOWED_HOSTS`.
+`403 Forbidden Origin` → add the browser `Origin` to `MATTERMOST_HTTP_ALLOWED_ORIGINS`.
 
 ## Environment File
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,17 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |
+| `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP` | false | Allow `static_token` over HTTP — loopback bind only. See [Authentication](authentication.md#static_token) |
+| `MATTERMOST_HTTP_ALLOWED_HOSTS` | — | Extra allowed `Host` values for HTTP (JSON array or comma-separated) |
+| `MATTERMOST_HTTP_ALLOWED_ORIGINS` | — | Extra allowed `Origin` values for HTTP (JSON array or comma-separated) |
+
+## HTTP transport security
+
+The HTTP transport enables DNS-rebinding protection automatically (`host_origin_protection="auto"`):
+loopback deployments reject unknown `Host`/`Origin` headers, while non-loopback binds are unaffected
+until you declare an allowlist. Set `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS`
+to enforce strict validation for a networked deployment (e.g. the public host behind a reverse proxy).
+`X-Forwarded-*` headers are not trusted automatically.
 
 ## Environment File
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,18 +32,45 @@ but never blocks. See [Authentication → HTTP transport](authentication.md#http
 posture and its remediation. This section covers the transport-level Host/Origin protection, which applies
 to every auth mode.
 
-The HTTP transport turns on DNS-rebinding protection automatically (`host_origin_protection="auto"`):
-
-- **Loopback bind** (`127.0.0.1` / `localhost` / `::1`) — `Host` and `Origin` are validated. Normal MCP
-  clients (loopback `Host`, no `Origin`) pass; an unknown `Host` gets `421`, a foreign `Origin` gets `403`.
-- **Non-loopback bind** (`0.0.0.0`, LAN IP) — validation is **off** until you set an allowlist, so it does
-  not protect a networked deployment on its own.
+The HTTP transport turns on DNS-rebinding protection automatically (`host_origin_protection="auto"`). Each
+connection is classified by the **local address it arrived on**, not by the bind address: a server bound to
+`0.0.0.0` validates a request that reaches it through `127.0.0.1` and skips one that reaches it through a
+LAN address.
 
 Declare allowlists with `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` (JSON array or
-comma-separated) — e.g. the public host behind a reverse proxy. `X-Forwarded-*` headers are not trusted.
+comma-separated) — e.g. the public host behind a reverse proxy. Cells name the headers that get validated;
+column heads drop the `MATTERMOST_HTTP_` prefix.
 
-**Troubleshooting:** `421 Misdirected Request` → add the client's `Host` to `MATTERMOST_HTTP_ALLOWED_HOSTS`.
-`403 Forbidden Origin` → add the browser `Origin` to `MATTERMOST_HTTP_ALLOWED_ORIGINS`.
+| Connection arrived on | No allowlist | `ALLOWED_HOSTS` set | `ALLOWED_ORIGINS` only |
+|-----------------------|--------------|---------------------|------------------------|
+| `127.0.0.1`, `localhost`, `::1` | `Host` + `Origin` | `Host` + `Origin` | `Host` + `Origin` |
+| LAN or public address | none | `Host` + `Origin` | `Origin` |
+
+Accepted in every configuration: `Host: 127.0.0.1` / `localhost` / `::1`, the local address the connection
+arrived on, and any loopback `Origin` when `Host` is loopback. A request with no `Origin` header — every
+non-browser MCP client — is never rejected on `Origin`. Allowlist entries are glob patterns
+(`*.example.com`). `X-Forwarded-*` headers are not trusted.
+
+**Upgrade note:** a same-host reverse proxy or health checker that connects over `127.0.0.1` while
+preserving a public `Host`/`Origin` is validated even on a `0.0.0.0` bind — list its values in
+`MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS`.
+
+Three behaviors behind a surprising `421`/`403`:
+
+- `MATTERMOST_HTTP_ALLOWED_ORIGINS` **alone** drops the same-origin exemption for non-loopback arrivals: a
+  same-origin browser request then gets `403` unless its origin is listed. Set
+  `MATTERMOST_HTTP_ALLOWED_HOSTS` as well, or list every origin the browser sends.
+- `Host` matching ignores the port, `Origin` matching includes it. `https://app.example.com` means port 443,
+  so list `https://app.example.com:8443` explicitly.
+- A request arriving off-loopback but carrying `Host: localhost` has its `Origin` validated even with no
+  allowlist set — a proxy using `proxy_set_header Host localhost` needs its `Origin` listed.
+
+**Troubleshooting**
+
+| Symptom | Fix |
+|---------|-----|
+| `421 Misdirected Request` | Add the client's `Host` to `MATTERMOST_HTTP_ALLOWED_HOSTS` |
+| `403 Forbidden Origin` | Add the browser `Origin`, with port, to `MATTERMOST_HTTP_ALLOWED_ORIGINS` |
 
 ## Environment File
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |
 | `MATTERMOST_API_VERSION` | v4 | Mattermost API version |
+| `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` | — | Host/Origin protection: `off`, `auto`, or `strict` (unset: FastMCP's own default, off) |
 | `MATTERMOST_HTTP_ALLOWED_HOSTS` | — | Extra allowed `Host` values for HTTP (JSON array or comma-separated) |
 | `MATTERMOST_HTTP_ALLOWED_ORIGINS` | — | Extra allowed `Origin` values for HTTP (JSON array or comma-separated) |
 
@@ -32,30 +33,53 @@ but never blocks. See [Authentication → HTTP transport](authentication.md#http
 posture and its remediation. This section covers the transport-level Host/Origin protection, which applies
 to every auth mode.
 
-The HTTP transport turns on DNS-rebinding protection automatically (`host_origin_protection="auto"`). Each
-connection is classified by the **local address it arrived on**, not by the bind address: a server bound to
-`0.0.0.0` validates a request that reaches it through `127.0.0.1` and skips one that reaches it through a
-LAN address.
+DNS-rebinding protection is **off unless you turn it on** — an upgrade never starts rejecting traffic that
+worked before. Set `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION`:
+
+| Value | Effect |
+|-------|--------|
+| unset | Defers to FastMCP's own `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION`, which is off by default |
+| `off` | Never validate, overriding `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` |
+| `auto` | Validate per connection, by the local address it arrived on |
+| `strict` | Validate every connection, whatever address it arrived on |
+
+The setting applies to every way of serving the app — the `mcp-server-mattermost --http` command,
+`fastmcp run`, a standalone ASGI server, and this app mounted into a parent Starlette/FastAPI application.
 
 Declare allowlists with `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS` (JSON array or
-comma-separated) — e.g. the public host behind a reverse proxy. Cells name the headers that get validated;
-column heads drop the `MATTERMOST_HTTP_` prefix.
+comma-separated) — e.g. the public host behind a reverse proxy. They have no effect while protection is off;
+the server logs a warning when it sees that combination.
+
+Under `auto`, each connection is classified by the **local address it arrived on**, not by the bind address.
+Cells name the headers that get validated; column heads drop the `MATTERMOST_HTTP_` prefix.
 
 | Connection arrived on | No allowlist | `ALLOWED_HOSTS` set | `ALLOWED_ORIGINS` only |
 |-----------------------|--------------|---------------------|------------------------|
 | `127.0.0.1`, `localhost`, `::1` | `Host` + `Origin` | `Host` + `Origin` | `Host` + `Origin` |
-| LAN or public address | none | `Host` + `Origin` | `Origin` |
+| LAN or public address | none, unless the request carries `Host: localhost` — then `Origin` | `Host` + `Origin` | `Origin` |
+
+**A loopback bind is a special case of the first row.** On `MCP_HOST=127.0.0.1` (the default) FastMCP adds
+the bind address to the allowlist, so with `auto` every connection has its `Host` validated — a reverse proxy
+that forwards a public `Host` needs it in `MATTERMOST_HTTP_ALLOWED_HOSTS`. The same holds for a proxy or
+health checker reaching a `0.0.0.0` bind over `127.0.0.1`.
 
 Accepted in every configuration: `Host: 127.0.0.1` / `localhost` / `::1`, the local address the connection
 arrived on, and any loopback `Origin` when `Host` is loopback. A request with no `Origin` header — every
-non-browser MCP client — is never rejected on `Origin`. Allowlist entries are glob patterns
-(`*.example.com`). `X-Forwarded-*` headers are not trusted.
+non-browser MCP client — is never rejected on `Origin`.
 
-**Upgrade note:** a same-host reverse proxy or health checker that connects over `127.0.0.1` while
-preserving a public `Host`/`Origin` is validated even on a `0.0.0.0` bind — list its values in
-`MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS`.
+Allowlist entries are `fnmatch` glob patterns, which is looser than it looks:
 
-Three behaviors behind a surprising `421`/`403`:
+- `*.example.com` does **not** match the apex `example.com`. List both if you need both.
+- `*` crosses dots, so `*.example.com` matches `a.b.example.com` — and `evil.attacker.com.example.com`.
+  Prefer exact hostnames over wildcards where you can.
+- A bare `*` matches everything, disabling the check for that header.
+
+`X-Forwarded-Host` is ignored and the arrival address is never taken from a header, so a proxy cannot talk
+the guard into trusting a hostname. `X-Forwarded-Proto` **is** honored: uvicorn's proxy-header handling is on
+by default for peers in `forwarded_allow_ips` (loopback unless `FORWARDED_ALLOW_IPS` says otherwise) and it
+sets the scheme used for the same-origin comparison.
+
+Four behaviors behind a surprising `421`/`403`:
 
 - `MATTERMOST_HTTP_ALLOWED_ORIGINS` **alone** drops the same-origin exemption for non-loopback arrivals: a
   same-origin browser request then gets `403` unless its origin is listed. Set
@@ -64,6 +88,11 @@ Three behaviors behind a surprising `421`/`403`:
   so list `https://app.example.com:8443` explicitly.
 - A request arriving off-loopback but carrying `Host: localhost` has its `Origin` validated even with no
   allowlist set — a proxy using `proxy_set_header Host localhost` needs its `Origin` listed.
+- Behind a proxy terminating TLS, the browser sends `Origin: https://…` while the server still sees scheme
+  `http`, so the same-origin exemption misses. See the troubleshooting table below.
+
+Every rejection is logged at `WARNING` with the offending `Host`/`Origin` and the variable to add it to; the
+response body itself stays a bare `421`/`403`.
 
 **Troubleshooting**
 
@@ -71,6 +100,8 @@ Three behaviors behind a surprising `421`/`403`:
 |---------|-----|
 | `421 Misdirected Request` | Add the client's `Host` to `MATTERMOST_HTTP_ALLOWED_HOSTS` |
 | `403 Forbidden Origin` | Add the browser `Origin`, with port, to `MATTERMOST_HTTP_ALLOWED_ORIGINS` |
+| `403` behind a TLS-terminating proxy, `Origin` looks correct | Have the proxy send `X-Forwarded-Proto: https`, and set `FORWARDED_ALLOW_IPS` to the proxy's address if it is not on loopback |
+| Allowlist appears to be ignored | `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` is unset or `off` |
 
 ## Environment File
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,14 +39,16 @@ docker run -i --rm \
 
 ## HTTP Mode (Production)
 
-For production deployments with health checks:
+HTTP with `static_token` is refused unless bound to loopback with an explicit opt-in, because it would
+otherwise expose an unauthenticated endpoint acting with the shared token. For networked deployments use
+per-client auth — `oauth_proxy` (below) or `client_token`:
 
 ```bash
 docker run -d -p 8000:8000 \
   -e MCP_TRANSPORT=http \
   -e MCP_HOST=0.0.0.0 \
+  -e MATTERMOST_AUTH_MODE=client_token \
   -e MATTERMOST_URL=https://your-mattermost.com \
-  -e MATTERMOST_TOKEN=your-token \
   legard/mcp-server-mattermost
 ```
 
@@ -55,6 +57,30 @@ Health check endpoint:
 ```bash
 curl http://localhost:8000/health
 ```
+
+### Keeping `static_token` behind an auth proxy
+
+To front the server with an authenticating proxy and still use `static_token`, co-locate the proxy in the
+same network namespace and bind the MCP server to loopback (the proxy publishes the port):
+
+```yaml
+services:
+  auth-proxy:
+    image: your-auth-proxy
+    ports: ["8000:8000"]
+  mattermost-mcp:
+    image: legard/mcp-server-mattermost
+    network_mode: "service:auth-proxy"   # shares localhost with the proxy
+    environment:
+      MCP_TRANSPORT: http
+      MCP_HOST: 127.0.0.1
+      MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP: "true"
+      MATTERMOST_URL: https://your-mattermost.com
+      MATTERMOST_TOKEN: your-token
+```
+
+DNS-rebinding protection is on by default. If the proxy forwards the public `Host`, add it to
+`MATTERMOST_HTTP_ALLOWED_HOSTS`. `X-Forwarded-*` headers are not trusted automatically.
 
 ## HTTP Mode with Mattermost OAuth Proxy
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,10 +39,9 @@ docker run -i --rm \
 
 ## HTTP Mode (Production)
 
-HTTP with `static_token` on a non-loopback bind starts but logs a loud warning: it exposes an
-unauthenticated endpoint acting with the shared token to the network. Either front it with an
-authenticating reverse proxy, or — recommended for networked deployments — use per-client auth,
-`oauth_proxy` (below) or `client_token`:
+For networked HTTP use per-client auth: `client_token` (below) or `oauth_proxy` (below). `static_token`
+over HTTP serves an unauthenticated endpoint and only warns — it does not block; see
+[Authentication → HTTP transport](authentication.md#http-transport):
 
 ```bash
 docker run -d -p 8000:8000 \

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,9 +39,10 @@ docker run -i --rm \
 
 ## HTTP Mode (Production)
 
-HTTP with `static_token` is refused unless bound to loopback with an explicit opt-in, because it would
-otherwise expose an unauthenticated endpoint acting with the shared token. For networked deployments use
-per-client auth — `oauth_proxy` (below) or `client_token`:
+HTTP with `static_token` on a non-loopback bind starts but logs a loud warning: it exposes an
+unauthenticated endpoint acting with the shared token to the network. Either front it with an
+authenticating reverse proxy, or — recommended for networked deployments — use per-client auth,
+`oauth_proxy` (below) or `client_token`:
 
 ```bash
 docker run -d -p 8000:8000 \
@@ -60,8 +61,10 @@ curl http://localhost:8000/health
 
 ### Keeping `static_token` behind an auth proxy
 
-To front the server with an authenticating proxy and still use `static_token`, co-locate the proxy in the
-same network namespace and bind the MCP server to loopback (the proxy publishes the port):
+A `static_token` server behind an authenticating proxy starts on any bind (the warning is expected here —
+the proxy provides authentication). To also make the server **unreachable except through the proxy**,
+co-locate the proxy in the same network namespace and bind the MCP server to loopback (the proxy publishes
+the port):
 
 ```yaml
 services:
@@ -74,13 +77,12 @@ services:
     environment:
       MCP_TRANSPORT: http
       MCP_HOST: 127.0.0.1
-      MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP: "true"
       MATTERMOST_URL: https://your-mattermost.com
       MATTERMOST_TOKEN: your-token
 ```
 
-DNS-rebinding protection is on by default. If the proxy forwards the public `Host`, add it to
-`MATTERMOST_HTTP_ALLOWED_HOSTS`. `X-Forwarded-*` headers are not trusted automatically.
+On this loopback bind, DNS-rebinding protection is active. If the proxy forwards the public `Host`, add it
+to `MATTERMOST_HTTP_ALLOWED_HOSTS`. `X-Forwarded-*` headers are not trusted automatically.
 
 ## HTTP Mode with Mattermost OAuth Proxy
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -49,8 +49,17 @@ docker run -d -p 8000:8000 \
   -e MCP_HOST=0.0.0.0 \
   -e MATTERMOST_AUTH_MODE=client_token \
   -e MATTERMOST_URL=https://your-mattermost.com \
+  -e MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION=auto \
+  -e MATTERMOST_HTTP_ALLOWED_HOSTS=mcp.example.com \
   legard/mcp-server-mattermost
 ```
+
+In `client_token` mode every MCP client must send its own Mattermost token as
+`Authorization: Bearer <token>`; requests without one get `401`.
+
+A published-port container receives connections on its bridge address, which `auto` does not validate on its
+own — declare `MATTERMOST_HTTP_ALLOWED_HOSTS` (the public hostname clients use) to turn the check on there.
+See [HTTP transport security](configuration.md#http-transport-security).
 
 Health check endpoint:
 
@@ -65,24 +74,30 @@ the proxy provides authentication). To also make the server **unreachable except
 co-locate the proxy in the same network namespace and bind the MCP server to loopback (the proxy publishes
 the port):
 
+The two containers share one network namespace, so they need different ports: the proxy publishes 8000 and
+forwards to the MCP server on 8001.
+
 ```yaml
 services:
   auth-proxy:
     image: your-auth-proxy
-    ports: ["8000:8000"]
+    ports: ["8000:8000"]                 # upstream: 127.0.0.1:8001
   mattermost-mcp:
     image: legard/mcp-server-mattermost
     network_mode: "service:auth-proxy"   # shares localhost with the proxy
     environment:
       MCP_TRANSPORT: http
       MCP_HOST: 127.0.0.1
+      MCP_PORT: 8001
       MATTERMOST_URL: https://your-mattermost.com
       MATTERMOST_TOKEN: your-token
+      MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION: auto
 ```
 
-Every connection here arrives over loopback, so `Host`/`Origin` validation is active. If the proxy forwards
-the public `Host`, add it to `MATTERMOST_HTTP_ALLOWED_HOSTS`. `X-Forwarded-*` headers are not trusted
-automatically.
+Every connection here arrives over loopback, so with `auto` the `Host` and `Origin` are validated. If the
+proxy forwards the public `Host`, add it to `MATTERMOST_HTTP_ALLOWED_HOSTS`, or the server answers `421`.
+`X-Forwarded-Host` is never trusted; `X-Forwarded-Proto` is honored from loopback peers, which the proxy is
+here.
 
 ## HTTP Mode with Mattermost OAuth Proxy
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -80,8 +80,9 @@ services:
       MATTERMOST_TOKEN: your-token
 ```
 
-On this loopback bind, DNS-rebinding protection is active. If the proxy forwards the public `Host`, add it
-to `MATTERMOST_HTTP_ALLOWED_HOSTS`. `X-Forwarded-*` headers are not trusted automatically.
+Every connection here arrives over loopback, so `Host`/`Origin` validation is active. If the proxy forwards
+the public `Host`, add it to `MATTERMOST_HTTP_ALLOWED_HOSTS`. `X-Forwarded-*` headers are not trusted
+automatically.
 
 ## HTTP Mode with Mattermost OAuth Proxy
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -83,6 +83,7 @@ and posts a report highlighting what still needs attention:
 
 **Example attachment payload:**
 
+<!--- pyml disable-num-lines 12 line-length -->
 ```json
 {
   "channel_id": "support-channel-id",
@@ -120,6 +121,7 @@ structured release notes — grouped by category, each with its own color:
 
 **Example attachment payload:**
 
+<!--- pyml disable-num-lines 23 line-length -->
 ```json
 {
   "channel_id": "releases-channel-id",
@@ -279,7 +281,8 @@ to Mattermost; the summary stays in your conversation with the AI.
 
 ## Project Kickoff
 
-> "Set up a channel for Project Phoenix — private, invite @alice, @bob and @carol, and post a welcome message with the project goals"
+> "Set up a channel for Project Phoenix — private, invite @alice, @bob and @carol,
+> and post a welcome message with the project goals"
 
 A single prompt triggers a chain of 7+ tool calls:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "cachetools>=5.0",
     "certifi",
-    "fastmcp>=3.4,<4",
+    "fastmcp>=3.4.4,<4",
     "httpx>=0.28.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+docs = [
+    "mkdocs-material",
+]
+
+[dependency-groups]
 dev = [
     "asgi-lifespan>=2.1.0",
     "pytest>=8.0",
@@ -49,9 +54,6 @@ dev = [
     "testcontainers[postgres]>=4.0",
     "pymarkdownlnt>=0.9.35",
     "types-cachetools",
-]
-docs = [
-    "mkdocs-material",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "fastmcp>=3.4.4,<4",
     "httpx>=0.28.0",
     "pydantic>=2.0",
-    "pydantic-settings>=2.0",
+    "pydantic-settings>=2.7",
     "tenacity>=9.0.0",
     "wsproto>=1.3.2",
 ]

--- a/src/mcp_server_mattermost/__init__.py
+++ b/src/mcp_server_mattermost/__init__.py
@@ -73,10 +73,38 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if not args.http:
+        from .server import mcp  # noqa: PLC0415
+
+        with contextlib.suppress(KeyboardInterrupt):
+            mcp.run(transport="stdio")
+        return
+
+    # HTTP transport: enforce transport security before importing/binding the server.
+    from mcp_server_mattermost.config import get_settings  # noqa: PLC0415
+    from mcp_server_mattermost.exceptions import ConfigurationError  # noqa: PLC0415
+    from mcp_server_mattermost.http_security import (  # noqa: PLC0415
+        enforce_unauthenticated_http_policy,
+        resolve_host_origin_kwargs,
+    )
+    from mcp_server_mattermost.logging import logger, setup_logging  # noqa: PLC0415
+
+    settings = get_settings()
+    try:
+        warning = enforce_unauthenticated_http_policy(settings, transport="http", host=args.host)
+    except ConfigurationError as exc:
+        raise SystemExit(str(exc)) from exc
+    if warning:
+        setup_logging(settings.log_level, settings.log_format)
+        logger.warning(warning)
+
     from .server import mcp  # noqa: PLC0415
 
     with contextlib.suppress(KeyboardInterrupt):
-        if args.http:
-            mcp.run(transport="http", host=args.host, port=args.port, uvicorn_config={"ws": "wsproto"})
-        else:
-            mcp.run(transport="stdio")
+        mcp.run(
+            transport="http",
+            host=args.host,
+            port=args.port,
+            uvicorn_config={"ws": "wsproto"},
+            **resolve_host_origin_kwargs(settings),
+        )

--- a/src/mcp_server_mattermost/__init__.py
+++ b/src/mcp_server_mattermost/__init__.py
@@ -80,20 +80,16 @@ def main() -> None:
             mcp.run(transport="stdio")
         return
 
-    # HTTP transport: enforce transport security before importing/binding the server.
+    # HTTP transport: surface any transport-security warning before importing/binding the server.
     from mcp_server_mattermost.config import get_settings  # noqa: PLC0415
-    from mcp_server_mattermost.exceptions import ConfigurationError  # noqa: PLC0415
     from mcp_server_mattermost.http_security import (  # noqa: PLC0415
-        enforce_unauthenticated_http_policy,
         resolve_host_origin_kwargs,
+        unauthenticated_http_warning,
     )
     from mcp_server_mattermost.logging import logger, setup_logging  # noqa: PLC0415
 
     settings = get_settings()
-    try:
-        warning = enforce_unauthenticated_http_policy(settings, transport="http", host=args.host)
-    except ConfigurationError as exc:
-        raise SystemExit(str(exc)) from exc
+    warning = unauthenticated_http_warning(settings, transport="http", host=args.host)
     if warning:
         setup_logging(settings.log_level, settings.log_format)
         logger.warning(warning)

--- a/src/mcp_server_mattermost/__init__.py
+++ b/src/mcp_server_mattermost/__init__.py
@@ -80,23 +80,26 @@ def main() -> None:
             mcp.run(transport="stdio")
         return
 
-    # HTTP transport: surface the transport-security posture and warnings before importing/binding the server.
     from mcp_server_mattermost.config import get_settings  # noqa: PLC0415
     from mcp_server_mattermost.http_security import (  # noqa: PLC0415
         host_origin_posture,
-        resolve_host_origin_kwargs,
+        inert_allowlist_warning,
         unauthenticated_http_warning,
     )
     from mcp_server_mattermost.logging import logger, setup_logging  # noqa: PLC0415
 
+    # Importing the server applies the Host/Origin protection, so the posture below reflects it.
+    from .server import mcp  # noqa: PLC0415
+
     settings = get_settings()
     setup_logging(settings.log_level, settings.log_format)
-    logger.info(host_origin_posture(settings))
-    warning = unauthenticated_http_warning(settings, transport="http", host=args.host)
-    if warning:
-        logger.warning(warning)
-
-    from .server import mcp  # noqa: PLC0415
+    logger.info(host_origin_posture(settings, host=args.host))
+    for warning in (
+        inert_allowlist_warning(settings),
+        unauthenticated_http_warning(settings, transport="http", host=args.host),
+    ):
+        if warning:
+            logger.warning(warning)
 
     with contextlib.suppress(KeyboardInterrupt):
         mcp.run(
@@ -104,5 +107,4 @@ def main() -> None:
             host=args.host,
             port=args.port,
             uvicorn_config={"ws": "wsproto"},
-            **resolve_host_origin_kwargs(settings),
         )

--- a/src/mcp_server_mattermost/__init__.py
+++ b/src/mcp_server_mattermost/__init__.py
@@ -80,18 +80,20 @@ def main() -> None:
             mcp.run(transport="stdio")
         return
 
-    # HTTP transport: surface any transport-security warning before importing/binding the server.
+    # HTTP transport: surface the transport-security posture and warnings before importing/binding the server.
     from mcp_server_mattermost.config import get_settings  # noqa: PLC0415
     from mcp_server_mattermost.http_security import (  # noqa: PLC0415
+        host_origin_posture,
         resolve_host_origin_kwargs,
         unauthenticated_http_warning,
     )
     from mcp_server_mattermost.logging import logger, setup_logging  # noqa: PLC0415
 
     settings = get_settings()
+    setup_logging(settings.log_level, settings.log_format)
+    logger.info(host_origin_posture(settings))
     warning = unauthenticated_http_warning(settings, transport="http", host=args.host)
     if warning:
-        setup_logging(settings.log_level, settings.log_format)
         logger.warning(warning)
 
     from .server import mcp  # noqa: PLC0415

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -85,10 +85,6 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format: 'json' or 'text'")
     api_version: str = Field(default="v4", description="Mattermost API version")
-    allow_unauthenticated_http: bool = Field(
-        default=False,
-        description="Allow static_token over HTTP on loopback only (unauthenticated MCP endpoint)",
-    )
     http_allowed_hosts: Annotated[list[str] | None, NoDecode] = Field(
         default=None,
         description="Extra allowed Host header values for HTTP transport (JSON array or comma-separated)",

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -1,12 +1,14 @@
 """Configuration management using Pydantic Settings."""
 
+import json
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
+from typing import Annotated
 from urllib.parse import urlsplit
 
 from pydantic import Field, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class AuthMode(str, Enum):
@@ -83,6 +85,18 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format: 'json' or 'text'")
     api_version: str = Field(default="v4", description="Mattermost API version")
+    allow_unauthenticated_http: bool = Field(
+        default=False,
+        description="Allow static_token over HTTP on loopback only (unauthenticated MCP endpoint)",
+    )
+    http_allowed_hosts: Annotated[list[str] | None, NoDecode] = Field(
+        default=None,
+        description="Extra allowed Host header values for HTTP transport (JSON array or comma-separated)",
+    )
+    http_allowed_origins: Annotated[list[str] | None, NoDecode] = Field(
+        default=None,
+        description="Extra allowed Origin header values for HTTP transport (JSON array or comma-separated)",
+    )
 
     oauth_client_id: str | None = Field(default=None, description="Mattermost OAuth App client ID")
     oauth_client_type: OAuthClientType = Field(
@@ -156,6 +170,21 @@ class Settings(BaseSettings):
         if not v.startswith("/"):
             msg = "MATTERMOST_OAUTH_CALLBACK_PATH must start with '/'"
             raise ValueError(msg)
+        return v
+
+    @field_validator("http_allowed_hosts", "http_allowed_origins", mode="before")
+    @classmethod
+    def _parse_host_origin_list(cls, v: object) -> object:
+        """Accept a JSON array or a comma-separated string; blank string becomes None."""
+        if v is None or isinstance(v, list):
+            return v
+        if isinstance(v, str):
+            stripped = v.strip()
+            if not stripped:
+                return None
+            if stripped.startswith("["):
+                return json.loads(stripped)  # parse JSON array
+            return [item.strip() for item in stripped.split(",") if item.strip()]
         return v
 
     @model_validator(mode="after")

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -26,6 +26,18 @@ class OAuthClientType(str, Enum):
     CONFIDENTIAL = "confidential"
 
 
+class HostOriginProtection(str, Enum):
+    """Host/Origin (DNS-rebinding) protection level for the HTTP transport.
+
+    Leaving the setting unset is distinct from ``OFF``: unset defers to FastMCP's own
+    ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION``, while ``OFF`` overrides it.
+    """
+
+    OFF = "off"
+    AUTO = "auto"
+    STRICT = "strict"
+
+
 _LOCALHOST_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
@@ -56,6 +68,9 @@ class Settings(BaseSettings):
         MATTERMOST_LOG_LEVEL: Logging level (default: INFO)
         MATTERMOST_LOG_FORMAT: Log format, 'json' or 'text' (default: json)
         MATTERMOST_API_VERSION: API version (default: v4)
+        MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION: off, auto, or strict (default: FastMCP's own setting)
+        MATTERMOST_HTTP_ALLOWED_HOSTS: Extra allowed Host values (JSON array or comma-separated)
+        MATTERMOST_HTTP_ALLOWED_ORIGINS: Extra allowed Origin values (JSON array or comma-separated)
     """
 
     model_config = SettingsConfigDict(
@@ -85,6 +100,10 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format: 'json' or 'text'")
     api_version: str = Field(default="v4", description="Mattermost API version")
+    http_host_origin_protection: HostOriginProtection | None = Field(
+        default=None,
+        description="Host/Origin protection for HTTP transport: 'off', 'auto', or 'strict' (unset: FastMCP default)",
+    )
     http_allowed_hosts: Annotated[list[str] | None, NoDecode] = Field(
         default=None,
         description="Extra allowed Host header values for HTTP transport (JSON array or comma-separated)",
@@ -168,20 +187,46 @@ class Settings(BaseSettings):
             raise ValueError(msg)
         return v
 
+    @field_validator("http_host_origin_protection", mode="before")
+    @classmethod
+    def _normalize_host_origin_protection(cls, v: object) -> object:
+        """Accept any case; blank string becomes None."""
+        if isinstance(v, str):
+            stripped = v.strip()
+            return stripped.lower() or None
+        return v
+
     @field_validator("http_allowed_hosts", "http_allowed_origins", mode="before")
     @classmethod
     def _parse_host_origin_list(cls, v: object) -> object:
-        """Accept a JSON array or a comma-separated string; blank string becomes None."""
+        """Accept a JSON array or a comma-separated string; an empty result becomes None.
+
+        An empty list is not neutral downstream — FastMCP treats any non-None allowlist as
+        an explicit one and starts validating every connection — so it is normalized away.
+        """
         if v is None or isinstance(v, list):
-            return v
+            return v or None
         if isinstance(v, str):
-            stripped = v.strip()
-            if not stripped:
-                return None
-            if stripped.startswith("["):
-                return json.loads(stripped)  # parse JSON array
-            return [item.strip() for item in stripped.split(",") if item.strip()]
+            return cls._split_host_origin_entries(v) or None
         return v
+
+    @staticmethod
+    def _split_host_origin_entries(raw: str) -> list[str]:
+        """Split a raw allowlist string, preferring JSON and falling back to comma-separated.
+
+        The fallback is what makes bracketed IPv6 literals work: ``[::1]`` is not valid JSON,
+        and it is the canonical spelling of an IPv6 ``Host`` header value.
+        """
+        stripped = raw.strip()
+        if not stripped:
+            return []
+        try:
+            parsed = json.loads(stripped)
+        except ValueError:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+        return [item.strip() for item in stripped.split(",") if item.strip()]
 
     @model_validator(mode="after")
     def validate_auth_configuration(self) -> "Settings":

--- a/src/mcp_server_mattermost/http_guard_log.py
+++ b/src/mcp_server_mattermost/http_guard_log.py
@@ -1,0 +1,99 @@
+"""Operator-facing logging for Host/Origin guard rejections.
+
+FastMCP answers a rejected ``Host`` with a bare ``421 Misdirected Request`` and a rejected
+``Origin`` with ``403 Forbidden Origin``. Neither names the offending value nor the setting
+that would accept it, and the guard runs as the outermost middleware inside the Starlette
+app, so nothing installed through ``http_app(middleware=...)`` can observe the rejection.
+This middleware is inserted ahead of the guard to log what was rejected; the response the
+client receives is left untouched.
+"""
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from .logging import logger
+
+
+_GUARD_REJECTIONS = {
+    421: (b"Misdirected Request", "host", "MATTERMOST_HTTP_ALLOWED_HOSTS"),
+    403: (b"Forbidden Origin", "origin", "MATTERMOST_HTTP_ALLOWED_ORIGINS"),
+}
+
+_REJECTION_LOG = (
+    "HTTP request rejected by Host/Origin protection: %s=%r on %s (arrived on %s, status %d). "
+    "Add it to %s if this client is legitimate."
+)
+
+
+def _header(scope: Scope, name: str) -> str:
+    raw = name.encode()
+    headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+    for key, value in headers:
+        if key == raw:
+            return value.decode("latin-1")
+    return ""
+
+
+def _arrival_address(scope: Scope) -> str:
+    server = scope.get("server")
+    return f"{server[0]}:{server[1]}" if server else "unknown"
+
+
+class GuardRejectionLoggingMiddleware:
+    """Log rejections produced by FastMCP's ``HostOriginGuardMiddleware``."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Pass the request through, logging a guard rejection if one comes back.
+
+        Args:
+            scope: ASGI connection scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        status = 0
+
+        async def logging_send(message: Message) -> None:
+            nonlocal status
+            if message["type"] == "http.response.start":
+                status = message["status"]
+            elif message["type"] == "http.response.body":
+                self._log_if_rejection(scope, status, message.get("body", b""))
+                status = 0
+            await send(message)
+
+        await self.app(scope, receive, logging_send)
+
+    def _log_if_rejection(self, scope: Scope, status: int, body: bytes) -> None:
+        """Log when the response body identifies it as a guard rejection.
+
+        Matching on the body keeps an authentication ``403`` from being reported as an
+        ``Origin`` rejection. If FastMCP ever rewords its guard responses this stops
+        logging rather than logging something untrue; ``tests/test_http_guard_log.py``
+        drives the real guard so the drift surfaces.
+
+        Args:
+            scope: ASGI connection scope.
+            status: Response status code.
+            body: First body chunk of the response.
+        """
+        rejection = _GUARD_REJECTIONS.get(status)
+        if rejection is None:
+            return
+        expected_body, header_name, env_var = rejection
+        if body.strip() != expected_body:
+            return
+        logger.warning(
+            _REJECTION_LOG,
+            header_name,
+            _header(scope, header_name),
+            scope.get("path", ""),
+            _arrival_address(scope),
+            status,
+            env_var,
+        )

--- a/src/mcp_server_mattermost/http_security.py
+++ b/src/mcp_server_mattermost/http_security.py
@@ -1,41 +1,34 @@
-"""Transport-security guards for the HTTP transport.
+"""Transport-security advisories for the HTTP transport.
 
 The ``static_token`` auth mode runs the MCP endpoint with no client authentication:
-the shared Mattermost token is used server-side for every tool call. Exposing that
-over HTTP lets any network peer drive the tools with the token's privileges, so this
-module refuses that combination unless it is explicitly opted into on loopback, and
-resolves the FastMCP Host/Origin (DNS-rebinding) protection settings.
+the shared Mattermost token is used server-side for every tool call. This module warns
+(but never refuses) when that mode is served over HTTP — a plain warning on a loopback
+bind, a louder one on a non-loopback bind where any reachable peer can drive the tools
+with the token's privileges — matching the MCP spec's posture (auth is a SHOULD, and the
+hard control is Host/Origin validation). It also resolves the FastMCP Host/Origin
+(DNS-rebinding) protection settings.
 """
 
 import ipaddress
 from typing import Literal, TypedDict
 
 from .config import AuthMode, Settings
-from .exceptions import ConfigurationError
 
 
-_LOOPBACK_REFUSAL = (
-    "HTTP transport with MATTERMOST_AUTH_MODE=static_token exposes an MCP endpoint that "
-    "requires no client authentication and executes tools with the shared Mattermost token. "
-    "Refusing to start. "
-    "To run on loopback for local/single-host use, set MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true. "
-    "For networked or multi-user access, use MATTERMOST_AUTH_MODE=client_token or "
-    "MATTERMOST_AUTH_MODE=oauth_proxy instead."
-)
-
-_NON_LOOPBACK_REFUSAL = (
-    "HTTP transport with MATTERMOST_AUTH_MODE=static_token is bound to a non-loopback address "
-    "({host}) without client authentication. Refusing to start. "
-    "MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP only permits binding to loopback "
-    "(127.0.0.1 / ::1 / localhost). "
-    "For network exposure use MATTERMOST_AUTH_MODE=client_token or oauth_proxy, or place an "
-    "authenticating reverse proxy in the same network namespace and bind this server to loopback."
+_NON_LOOPBACK_WARNING = (
+    "Unauthenticated HTTP on a non-loopback address ({host}): the MCP endpoint executes tools "
+    "with the shared Mattermost token and performs NO client authentication, so any peer that can "
+    "reach {host} can drive the tools with the token's privileges. Put an authenticating reverse "
+    "proxy in front, or switch to MATTERMOST_AUTH_MODE=client_token or oauth_proxy. Set "
+    "MATTERMOST_HTTP_ALLOWED_HOSTS / MATTERMOST_HTTP_ALLOWED_ORIGINS to enable Host/Origin "
+    "DNS-rebinding protection for this bind."
 )
 
 _LOOPBACK_WARNING = (
-    "Unauthenticated HTTP enabled on loopback (MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true). "
-    "The MCP endpoint executes tools with the shared Mattermost token and performs no client "
-    "authentication. Ensure this host is trusted. Host/Origin DNS-rebinding protection is active."
+    "Unauthenticated HTTP on loopback: the MCP endpoint executes tools with the shared "
+    "Mattermost token and performs no client authentication. Ensure this host is trusted; "
+    "for networked or multi-user access use MATTERMOST_AUTH_MODE=client_token or oauth_proxy. "
+    "Host/Origin DNS-rebinding protection is active."
 )
 
 
@@ -57,8 +50,11 @@ def is_loopback_host(host: str) -> bool:
         return False
 
 
-def enforce_unauthenticated_http_policy(settings: Settings, *, transport: str, host: str) -> str | None:
-    """Enforce the fail-closed policy for unauthenticated HTTP.
+def unauthenticated_http_warning(settings: Settings, *, transport: str, host: str) -> str | None:
+    """Return a security warning when static_token is served unauthenticated over HTTP.
+
+    Never refuses to start: the server always boots. The warning is louder on a
+    non-loopback bind, where the endpoint is reachable by network peers.
 
     Args:
         settings: Loaded application settings.
@@ -66,20 +62,14 @@ def enforce_unauthenticated_http_policy(settings: Settings, *, transport: str, h
         host: Bind host for HTTP transport.
 
     Returns:
-        A security warning string when the opted-in loopback combination is risky-but-allowed,
-        or None when there is nothing to warn about.
-
-    Raises:
-        ConfigurationError: When the transport / auth mode / host combination is forbidden.
+        A security warning string when static_token runs unauthenticated over HTTP
+        (louder for a non-loopback bind), or None when there is nothing to warn about.
     """
     if transport != "http" or settings.auth_mode is not AuthMode.STATIC_TOKEN:
         return None
 
     if not is_loopback_host(host):
-        raise ConfigurationError(_NON_LOOPBACK_REFUSAL.format(host=host))
-
-    if not settings.allow_unauthenticated_http:
-        raise ConfigurationError(_LOOPBACK_REFUSAL)
+        return _NON_LOOPBACK_WARNING.format(host=host)
 
     return _LOOPBACK_WARNING
 

--- a/src/mcp_server_mattermost/http_security.py
+++ b/src/mcp_server_mattermost/http_security.py
@@ -8,7 +8,7 @@ resolves the FastMCP Host/Origin (DNS-rebinding) protection settings.
 """
 
 import ipaddress
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from .config import AuthMode, Settings
 from .exceptions import ConfigurationError
@@ -87,7 +87,7 @@ def enforce_unauthenticated_http_policy(settings: Settings, *, transport: str, h
 class HostOriginRunKwargs(TypedDict):
     """Keyword arguments for ``mcp.run(transport="http", **kwargs)``."""
 
-    host_origin_protection: str
+    host_origin_protection: Literal["auto"]
     allowed_hosts: list[str] | None
     allowed_origins: list[str] | None
 

--- a/src/mcp_server_mattermost/http_security.py
+++ b/src/mcp_server_mattermost/http_security.py
@@ -8,6 +8,7 @@ resolves the FastMCP Host/Origin (DNS-rebinding) protection settings.
 """
 
 import ipaddress
+from typing import TypedDict
 
 from .config import AuthMode, Settings
 from .exceptions import ConfigurationError
@@ -83,7 +84,15 @@ def enforce_unauthenticated_http_policy(settings: Settings, *, transport: str, h
     return _LOOPBACK_WARNING
 
 
-def resolve_host_origin_kwargs(settings: Settings) -> dict[str, object]:
+class HostOriginRunKwargs(TypedDict):
+    """Keyword arguments for ``mcp.run(transport="http", **kwargs)``."""
+
+    host_origin_protection: str
+    allowed_hosts: list[str] | None
+    allowed_origins: list[str] | None
+
+
+def resolve_host_origin_kwargs(settings: Settings) -> HostOriginRunKwargs:
     """Build FastMCP Host/Origin protection kwargs for ``mcp.run(transport="http")``.
 
     Returns:

--- a/src/mcp_server_mattermost/http_security.py
+++ b/src/mcp_server_mattermost/http_security.py
@@ -1,0 +1,96 @@
+"""Transport-security guards for the HTTP transport.
+
+The ``static_token`` auth mode runs the MCP endpoint with no client authentication:
+the shared Mattermost token is used server-side for every tool call. Exposing that
+over HTTP lets any network peer drive the tools with the token's privileges, so this
+module refuses that combination unless it is explicitly opted into on loopback, and
+resolves the FastMCP Host/Origin (DNS-rebinding) protection settings.
+"""
+
+import ipaddress
+
+from .config import AuthMode, Settings
+from .exceptions import ConfigurationError
+
+
+_LOOPBACK_REFUSAL = (
+    "HTTP transport with MATTERMOST_AUTH_MODE=static_token exposes an MCP endpoint that "
+    "requires no client authentication and executes tools with the shared Mattermost token. "
+    "Refusing to start. "
+    "To run on loopback for local/single-host use, set MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true. "
+    "For networked or multi-user access, use MATTERMOST_AUTH_MODE=client_token or "
+    "MATTERMOST_AUTH_MODE=oauth_proxy instead."
+)
+
+_NON_LOOPBACK_REFUSAL = (
+    "HTTP transport with MATTERMOST_AUTH_MODE=static_token is bound to a non-loopback address "
+    "({host}) without client authentication. Refusing to start. "
+    "MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP only permits binding to loopback "
+    "(127.0.0.1 / ::1 / localhost). "
+    "For network exposure use MATTERMOST_AUTH_MODE=client_token or oauth_proxy, or place an "
+    "authenticating reverse proxy in the same network namespace and bind this server to loopback."
+)
+
+_LOOPBACK_WARNING = (
+    "Unauthenticated HTTP enabled on loopback (MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP=true). "
+    "The MCP endpoint executes tools with the shared Mattermost token and performs no client "
+    "authentication. Ensure this host is trusted. Host/Origin DNS-rebinding protection is active."
+)
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return whether the bind host is a loopback address.
+
+    Args:
+        host: Bind host (IP literal or hostname) from ``--host`` / ``MCP_HOST``.
+
+    Returns:
+        True for 127.0.0.0/8, ::1, or the literal "localhost"; False otherwise, including
+        0.0.0.0 / :: (unspecified) and any resolvable hostname, which are treated as public.
+    """
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def enforce_unauthenticated_http_policy(settings: Settings, *, transport: str, host: str) -> str | None:
+    """Enforce the fail-closed policy for unauthenticated HTTP.
+
+    Args:
+        settings: Loaded application settings.
+        transport: Resolved transport ("http" or "stdio").
+        host: Bind host for HTTP transport.
+
+    Returns:
+        A security warning string when the opted-in loopback combination is risky-but-allowed,
+        or None when there is nothing to warn about.
+
+    Raises:
+        ConfigurationError: When the transport / auth mode / host combination is forbidden.
+    """
+    if transport != "http" or settings.auth_mode is not AuthMode.STATIC_TOKEN:
+        return None
+
+    if not is_loopback_host(host):
+        raise ConfigurationError(_NON_LOOPBACK_REFUSAL.format(host=host))
+
+    if not settings.allow_unauthenticated_http:
+        raise ConfigurationError(_LOOPBACK_REFUSAL)
+
+    return _LOOPBACK_WARNING
+
+
+def resolve_host_origin_kwargs(settings: Settings) -> dict[str, object]:
+    """Build FastMCP Host/Origin protection kwargs for ``mcp.run(transport="http")``.
+
+    Returns:
+        Kwargs enabling "auto" DNS-rebinding protection plus any configured allowlists.
+    """
+    return {
+        "host_origin_protection": "auto",
+        "allowed_hosts": settings.http_allowed_hosts,
+        "allowed_origins": settings.http_allowed_origins,
+    }

--- a/src/mcp_server_mattermost/http_security.py
+++ b/src/mcp_server_mattermost/http_security.py
@@ -6,7 +6,8 @@ the shared Mattermost token is used server-side for every tool call. This module
 bind, a louder one on a non-loopback bind where any reachable peer can drive the tools
 with the token's privileges — matching the MCP spec's posture (auth is a SHOULD, and the
 hard control is Host/Origin validation). It also resolves the FastMCP Host/Origin
-(DNS-rebinding) protection settings.
+(DNS-rebinding) protection settings and summarizes the resulting per-connection posture
+for operators.
 """
 
 import ipaddress
@@ -19,9 +20,10 @@ _NON_LOOPBACK_WARNING = (
     "Unauthenticated HTTP on a non-loopback address ({host}): the MCP endpoint executes tools "
     "with the shared Mattermost token and performs NO client authentication, so any peer that can "
     "reach {host} can drive the tools with the token's privileges. Put an authenticating reverse "
-    "proxy in front, or switch to MATTERMOST_AUTH_MODE=client_token or oauth_proxy. Set "
-    "MATTERMOST_HTTP_ALLOWED_HOSTS / MATTERMOST_HTTP_ALLOWED_ORIGINS to enable Host/Origin "
-    "DNS-rebinding protection for this bind."
+    "proxy in front, or switch to MATTERMOST_AUTH_MODE=client_token or oauth_proxy. Host/Origin "
+    "DNS-rebinding protection is decided per connection from the local address it arrives on: loopback "
+    "arrivals are validated, other arrivals are not until you set MATTERMOST_HTTP_ALLOWED_HOSTS (Host "
+    "and Origin) or MATTERMOST_HTTP_ALLOWED_ORIGINS (Origin only)."
 )
 
 _LOOPBACK_WARNING = (
@@ -29,6 +31,12 @@ _LOOPBACK_WARNING = (
     "Mattermost token and performs no client authentication. Ensure this host is trusted; "
     "for networked or multi-user access use MATTERMOST_AUTH_MODE=client_token or oauth_proxy. "
     "Host/Origin DNS-rebinding protection is active."
+)
+
+_PROTECTION_POSTURE = (
+    "HTTP Host/Origin protection active (mode=auto, allowed_hosts={hosts}, allowed_origins={origins}). "
+    "Each connection is validated by the local address it arrives on: arrivals on 127.0.0.1/localhost/::1 "
+    "always, other arrivals only when an allowlist is set."
 )
 
 
@@ -72,6 +80,24 @@ def unauthenticated_http_warning(settings: Settings, *, transport: str, host: st
         return _NON_LOOPBACK_WARNING.format(host=host)
 
     return _LOOPBACK_WARNING
+
+
+def host_origin_posture(settings: Settings) -> str:
+    """Return an operator-facing summary of the active Host/Origin protection rule.
+
+    The rule is evaluated per connection, so the summary states the rule and the configured
+    allowlists rather than a single on/off verdict, which would not be true of every connection.
+
+    Args:
+        settings: Loaded application settings.
+
+    Returns:
+        A one-line message naming the configured allowlists and the per-connection rule.
+    """
+    return _PROTECTION_POSTURE.format(
+        hosts=f"[{', '.join(settings.http_allowed_hosts or [])}]",
+        origins=f"[{', '.join(settings.http_allowed_origins or [])}]",
+    )
 
 
 class HostOriginRunKwargs(TypedDict):

--- a/src/mcp_server_mattermost/http_security.py
+++ b/src/mcp_server_mattermost/http_security.py
@@ -1,47 +1,103 @@
-"""Transport-security advisories for the HTTP transport.
+"""Transport-security advisories and posture for the HTTP transport.
 
 The ``static_token`` auth mode runs the MCP endpoint with no client authentication:
 the shared Mattermost token is used server-side for every tool call. This module warns
 (but never refuses) when that mode is served over HTTP — a plain warning on a loopback
 bind, a louder one on a non-loopback bind where any reachable peer can drive the tools
 with the token's privileges — matching the MCP spec's posture (auth is a SHOULD, and the
-hard control is Host/Origin validation). It also resolves the FastMCP Host/Origin
-(DNS-rebinding) protection settings and summarizes the resulting per-connection posture
-for operators.
+hard control is Host/Origin validation).
+
+It also applies the Host/Origin (DNS-rebinding) protection to FastMCP's own settings, so
+the posture holds for every way of serving the app — ``mcp.run()``, ``fastmcp run``, an
+ASGI server over ``mcp.http_app()``, or the app mounted into a parent Starlette/FastAPI
+application — rather than only for the console entry point.
 """
 
 import ipaddress
-from typing import Literal, TypedDict
+from typing import Literal
 
-from .config import AuthMode, Settings
+import fastmcp
+
+from .config import AuthMode, HostOriginProtection, Settings
 
 
 _NON_LOOPBACK_WARNING = (
     "Unauthenticated HTTP on a non-loopback address ({host}): the MCP endpoint executes tools "
     "with the shared Mattermost token and performs NO client authentication, so any peer that can "
     "reach {host} can drive the tools with the token's privileges. Put an authenticating reverse "
-    "proxy in front, or switch to MATTERMOST_AUTH_MODE=client_token or oauth_proxy. Host/Origin "
-    "DNS-rebinding protection is decided per connection from the local address it arrives on: loopback "
-    "arrivals are validated, other arrivals are not until you set MATTERMOST_HTTP_ALLOWED_HOSTS (Host "
-    "and Origin) or MATTERMOST_HTTP_ALLOWED_ORIGINS (Origin only)."
+    "proxy in front, or switch to MATTERMOST_AUTH_MODE=client_token or oauth_proxy."
 )
 
 _LOOPBACK_WARNING = (
     "Unauthenticated HTTP on loopback: the MCP endpoint executes tools with the shared "
     "Mattermost token and performs no client authentication. Ensure this host is trusted; "
-    "for networked or multi-user access use MATTERMOST_AUTH_MODE=client_token or oauth_proxy. "
-    "Host/Origin DNS-rebinding protection is active."
+    "for networked or multi-user access use MATTERMOST_AUTH_MODE=client_token or oauth_proxy."
 )
 
-_PROTECTION_POSTURE = (
+_POSTURE_OFF = (
+    "HTTP Host/Origin protection is OFF: no request is rejected on its Host or Origin header. "
+    "Set MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION=auto to protect loopback arrivals against "
+    "DNS rebinding, or =strict to validate every connection. This default changes to 'auto' in "
+    "1.0.0 — set the variable explicitly (=off is a valid choice) to keep today's behavior across "
+    "that upgrade."
+)
+
+_POSTURE_AUTO = (
     "HTTP Host/Origin protection active (mode=auto, allowed_hosts={hosts}, allowed_origins={origins}). "
     "Each connection is validated by the local address it arrives on: arrivals on 127.0.0.1/localhost/::1 "
     "always, other arrivals only when an allowlist is set."
 )
 
+_POSTURE_AUTO_LOOPBACK_BIND = (
+    "HTTP Host/Origin protection active (mode=auto, bind={host}, allowed_hosts={hosts}, "
+    "allowed_origins={origins}). The bind is loopback, so FastMCP adds {host} to the allowlist and "
+    "validates Host and Origin on every connection — a reverse proxy forwarding a public Host must "
+    "have it listed in MATTERMOST_HTTP_ALLOWED_HOSTS."
+)
+
+_POSTURE_STRICT = (
+    "HTTP Host/Origin protection active (mode=strict, allowed_hosts={hosts}, allowed_origins={origins}). "
+    "Host and Origin are validated on every connection regardless of the address it arrives on."
+)
+
+_INERT_ALLOWLIST_WARNING = (
+    "MATTERMOST_HTTP_ALLOWED_HOSTS/MATTERMOST_HTTP_ALLOWED_ORIGINS are set but Host/Origin protection "
+    "is off, so they have no effect. Set MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION=auto or =strict to "
+    "enable them."
+)
+
+_FASTMCP_PROTECTION: dict[HostOriginProtection, bool | Literal["auto"]] = {
+    HostOriginProtection.OFF: False,
+    HostOriginProtection.AUTO: "auto",
+    HostOriginProtection.STRICT: True,
+}
+
+
+def normalize_host(host: str) -> str:
+    """Return a bare host, matching how FastMCP normalizes a Host header or bind address.
+
+    Args:
+        host: Raw host, optionally bracketed (``[::1]``) or carrying a port (``example:8000``).
+
+    Returns:
+        Lowercased host with surrounding whitespace, IPv6 brackets, and any trailing port removed.
+    """
+    host = host.strip().lower()
+    if not host:
+        return ""
+    if host.startswith("["):
+        end = host.find("]")
+        return host if end == -1 else host[1:end]
+    if host.count(":") == 1:
+        return host.rsplit(":", 1)[0]
+    return host
+
 
 def is_loopback_host(host: str) -> bool:
     """Return whether the bind host is a loopback address.
+
+    Mirrors FastMCP's own classification so the warnings this module emits describe the
+    posture FastMCP actually applies.
 
     Args:
         host: Bind host (IP literal or hostname) from ``--host`` / ``MCP_HOST``.
@@ -50,12 +106,50 @@ def is_loopback_host(host: str) -> bool:
         True for 127.0.0.0/8, ::1, or the literal "localhost"; False otherwise, including
         0.0.0.0 / :: (unspecified) and any resolvable hostname, which are treated as public.
     """
-    if host == "localhost":
+    normalized = normalize_host(host)
+    if normalized == "localhost":
         return True
     try:
-        return ipaddress.ip_address(host).is_loopback
+        return ipaddress.ip_address(normalized).is_loopback
     except ValueError:
         return False
+
+
+def apply_http_security_settings(settings: Settings) -> None:
+    """Push the configured Host/Origin protection into FastMCP's global settings.
+
+    FastMCP resolves ``host_origin_protection`` and the allowlists from ``fastmcp.settings``
+    whenever the corresponding keyword arguments are None, which every entry point does by
+    default. Writing them here therefore applies the posture uniformly instead of only on the
+    path that happens to pass keyword arguments to ``mcp.run()``.
+
+    Leaving ``MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION`` unset touches nothing, so FastMCP's
+    default (off) and an operator's own ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION`` both survive.
+
+    Args:
+        settings: Loaded application settings.
+    """
+    if settings.http_host_origin_protection is not None:
+        fastmcp.settings.http_host_origin_protection = _FASTMCP_PROTECTION[settings.http_host_origin_protection]
+    if settings.http_allowed_hosts is not None:
+        fastmcp.settings.http_allowed_hosts = settings.http_allowed_hosts
+    if settings.http_allowed_origins is not None:
+        fastmcp.settings.http_allowed_origins = settings.http_allowed_origins
+
+
+def effective_protection() -> HostOriginProtection:
+    """Return the Host/Origin protection level FastMCP will actually apply.
+
+    Returns:
+        The level resolved from FastMCP's settings, which reflects both this package's
+        configuration and FastMCP's own environment variables.
+    """
+    value = fastmcp.settings.http_host_origin_protection
+    if value is True:
+        return HostOriginProtection.STRICT
+    if value == "auto":
+        return HostOriginProtection.AUTO
+    return HostOriginProtection.OFF
 
 
 def unauthenticated_http_warning(settings: Settings, *, transport: str, host: str) -> str | None:
@@ -82,40 +176,44 @@ def unauthenticated_http_warning(settings: Settings, *, transport: str, host: st
     return _LOOPBACK_WARNING
 
 
-def host_origin_posture(settings: Settings) -> str:
-    """Return an operator-facing summary of the active Host/Origin protection rule.
+def host_origin_posture(settings: Settings, *, host: str) -> str:
+    """Return an operator-facing summary of the Host/Origin protection actually in effect.
 
-    The rule is evaluated per connection, so the summary states the rule and the configured
-    allowlists rather than a single on/off verdict, which would not be true of every connection.
+    Reports the level resolved from FastMCP's settings rather than this package's raw
+    configuration, so the line stays true when FastMCP's own environment variables are used.
+
+    Args:
+        settings: Loaded application settings.
+        host: Bind host for the HTTP transport.
+
+    Returns:
+        A one-line message naming the active level, the configured allowlists, and the
+        rule by which individual connections are validated.
+    """
+    protection = effective_protection()
+    if protection is HostOriginProtection.OFF:
+        return _POSTURE_OFF
+
+    hosts = repr(settings.http_allowed_hosts)
+    origins = repr(settings.http_allowed_origins)
+    if protection is HostOriginProtection.STRICT:
+        return _POSTURE_STRICT.format(hosts=hosts, origins=origins)
+    if is_loopback_host(host):
+        return _POSTURE_AUTO_LOOPBACK_BIND.format(host=host, hosts=hosts, origins=origins)
+    return _POSTURE_AUTO.format(hosts=hosts, origins=origins)
+
+
+def inert_allowlist_warning(settings: Settings) -> str | None:
+    """Return a warning when allowlists are configured but protection is off.
 
     Args:
         settings: Loaded application settings.
 
     Returns:
-        A one-line message naming the configured allowlists and the per-connection rule.
+        A warning string when an allowlist is set while protection is off, else None.
     """
-    return _PROTECTION_POSTURE.format(
-        hosts=f"[{', '.join(settings.http_allowed_hosts or [])}]",
-        origins=f"[{', '.join(settings.http_allowed_origins or [])}]",
-    )
-
-
-class HostOriginRunKwargs(TypedDict):
-    """Keyword arguments for ``mcp.run(transport="http", **kwargs)``."""
-
-    host_origin_protection: Literal["auto"]
-    allowed_hosts: list[str] | None
-    allowed_origins: list[str] | None
-
-
-def resolve_host_origin_kwargs(settings: Settings) -> HostOriginRunKwargs:
-    """Build FastMCP Host/Origin protection kwargs for ``mcp.run(transport="http")``.
-
-    Returns:
-        Kwargs enabling "auto" DNS-rebinding protection plus any configured allowlists.
-    """
-    return {
-        "host_origin_protection": "auto",
-        "allowed_hosts": settings.http_allowed_hosts,
-        "allowed_origins": settings.http_allowed_origins,
-    }
+    if effective_protection() is not HostOriginProtection.OFF:
+        return None
+    if settings.http_allowed_hosts is None and settings.http_allowed_origins is None:
+        return None
+    return _INERT_ALLOWLIST_WARNING

--- a/src/mcp_server_mattermost/server.py
+++ b/src/mcp_server_mattermost/server.py
@@ -2,15 +2,21 @@
 
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Literal
 
 from fastmcp import FastMCP
+from fastmcp.server.event_store import EventStore
+from fastmcp.server.http import StarletteWithLifespan
 from fastmcp.server.lifespan import lifespan
 from fastmcp.server.providers import FileSystemProvider
+from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .auth_factory import build_auth_provider_from_env
 from .config import get_settings
+from .http_guard_log import GuardRejectionLoggingMiddleware
+from .http_security import apply_http_security_settings
 from .logging import logger, setup_logging
 from .middleware import LoggingMiddleware
 from .tls import install_extra_ca_certs
@@ -38,18 +44,75 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[dict[str, object]]:
         logger.info("Mattermost MCP server shutdown complete")
 
 
-def _create_mcp() -> FastMCP:
-    """Create FastMCP instance with configured authentication.
+class MattermostMCP(FastMCP):
+    """FastMCP server that logs Host/Origin guard rejections on every HTTP app it builds."""
+
+    def http_app(  # noqa: PLR0913
+        self,
+        path: str | None = None,
+        middleware: list[Middleware] | None = None,
+        json_response: bool | None = None,  # noqa: FBT001
+        stateless_http: bool | None = None,  # noqa: FBT001
+        transport: Literal["http", "streamable-http", "sse"] = "http",
+        event_store: EventStore | None = None,
+        retry_interval: int | None = None,
+        host_origin_protection: bool | Literal["auto"] | None = None,  # noqa: FBT001
+        allowed_hosts: list[str] | None = None,
+        allowed_origins: list[str] | None = None,
+    ) -> StarletteWithLifespan:
+        """Build the HTTP app with rejection logging wrapped around the Host/Origin guard.
+
+        ``add_middleware`` prepends, so the logger ends up outside FastMCP's guard and can
+        observe the 421/403 it produces — anything passed via ``middleware`` runs inside it.
+
+        Args:
+            path: Endpoint path.
+            middleware: Additional ASGI middleware, applied inside the guard.
+            json_response: Whether to use JSON response format.
+            stateless_http: Whether to use stateless HTTP.
+            transport: Transport protocol to serve.
+            event_store: Event store for resumable streams.
+            retry_interval: SSE retry interval.
+            host_origin_protection: Host/Origin validation level; defaults to FastMCP settings.
+            allowed_hosts: Additional accepted Host header values.
+            allowed_origins: Additional accepted browser origins.
+
+        Returns:
+            The Starlette application, with rejection logging as its outermost middleware.
+        """
+        app = super().http_app(
+            path=path,
+            middleware=middleware,
+            json_response=json_response,
+            stateless_http=stateless_http,
+            transport=transport,
+            event_store=event_store,
+            retry_interval=retry_interval,
+            host_origin_protection=host_origin_protection,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
+        app.add_middleware(GuardRejectionLoggingMiddleware)
+        return app
+
+
+def _create_mcp() -> MattermostMCP:
+    """Create FastMCP instance with configured authentication and HTTP transport security.
 
     Settings are loaded through pydantic-settings so auth mode selection is
-    validated consistently across stdio and HTTP transports.
+    validated consistently across stdio and HTTP transports. The Host/Origin
+    protection is written into FastMCP's settings here, rather than passed to
+    ``mcp.run()``, so it also covers ``fastmcp run``, a standalone ASGI server,
+    and this app mounted into a parent Starlette/FastAPI application.
 
     Returns:
         Configured FastMCP server instance
     """
-    install_extra_ca_certs(get_settings())
+    settings = get_settings()
+    install_extra_ca_certs(settings)
+    apply_http_security_settings(settings)
     auth = build_auth_provider_from_env()
-    return FastMCP(
+    return MattermostMCP(
         name="Mattermost",
         instructions="MCP server for Mattermost team collaboration platform",
         lifespan=app_lifespan,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -422,3 +422,48 @@ class TestAuthModeSettings:
             pytest.raises(ValidationError, match="MATTERMOST_OAUTH_CALLBACK_PATH must start with '/'"),
         ):
             Settings()
+
+
+def test_http_security_settings_defaults(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings()
+    assert settings.allow_unauthenticated_http is False
+    assert settings.http_allowed_hosts is None
+    assert settings.http_allowed_origins is None
+
+
+def test_http_allowed_hosts_parses_csv(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", "a.example, b.example ,,")
+
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings()
+    assert settings.http_allowed_hosts == ["a.example", "b.example"]
+
+
+def test_http_allowed_origins_parses_json(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_ORIGINS", '["https://x.example","https://y.example"]')
+
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings()
+    assert settings.http_allowed_origins == ["https://x.example", "https://y.example"]
+
+
+def test_http_allowed_hosts_blank_is_none(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", "   ")
+
+    from mcp_server_mattermost.config import Settings
+
+    settings = Settings()
+    assert settings.http_allowed_hosts is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -431,7 +431,6 @@ def test_http_security_settings_defaults(monkeypatch):
     from mcp_server_mattermost.config import Settings
 
     settings = Settings()
-    assert settings.allow_unauthenticated_http is False
     assert settings.http_allowed_hosts is None
     assert settings.http_allowed_origins is None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -466,3 +466,61 @@ def test_http_allowed_hosts_blank_is_none(monkeypatch):
 
     settings = Settings()
     assert settings.http_allowed_hosts is None
+
+
+@pytest.mark.parametrize("raw", ["[]", ",", " , ", "[ ]"])
+def test_http_allowlist_empty_result_is_none(monkeypatch, raw):
+    """An empty list is not neutral: FastMCP treats it as an explicit allowlist matching nothing."""
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", raw)
+
+    from mcp_server_mattermost.config import Settings
+
+    assert Settings().http_allowed_hosts is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("[::1]", ["[::1]"]),
+        ("[::1],127.0.0.1", ["[::1]", "127.0.0.1"]),
+        ("[2001:db8::1]:8000", ["[2001:db8::1]:8000"]),
+        ('["[::1]"]', ["[::1]"]),
+    ],
+)
+def test_http_allowlist_accepts_bracketed_ipv6(monkeypatch, raw, expected):
+    """A bracketed IPv6 literal is the canonical Host spelling and is not valid JSON."""
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", raw)
+
+    from mcp_server_mattermost.config import Settings
+
+    assert Settings().http_allowed_hosts == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("off", "off"), ("AUTO", "auto"), (" strict ", "strict"), ("", None)],
+)
+def test_http_host_origin_protection_parsing(monkeypatch, raw, expected):
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION", raw)
+
+    from mcp_server_mattermost.config import Settings
+
+    value = Settings().http_host_origin_protection
+    assert (value.value if value else None) == expected
+
+
+def test_http_host_origin_protection_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_URL", "https://example.com")
+    monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+    monkeypatch.setenv("MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION", "on")
+
+    from mcp_server_mattermost.config import Settings
+
+    with pytest.raises(ValidationError):
+        Settings()

--- a/tests/test_http_guard_log.py
+++ b/tests/test_http_guard_log.py
@@ -1,0 +1,104 @@
+"""Tests for Host/Origin guard rejection logging.
+
+These drive the real ``HostOriginGuardMiddleware`` rather than a stub, so a reworded FastMCP
+guard response — which would silently stop the logging — fails here instead of in production.
+"""
+
+import fastmcp
+import pytest
+from starlette.testclient import TestClient
+
+from mcp_server_mattermost.http_guard_log import GuardRejectionLoggingMiddleware
+from mcp_server_mattermost.http_security import apply_http_security_settings
+
+
+LOOPBACK = "127.0.0.1:8030"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fastmcp_settings(monkeypatch):
+    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", False)
+    monkeypatch.setattr(fastmcp.settings, "http_allowed_hosts", None)
+    monkeypatch.setattr(fastmcp.settings, "http_allowed_origins", None)
+
+
+@pytest.fixture
+def client(mock_settings):
+    from mcp_server_mattermost.server import mcp
+
+    app = mcp.http_app(host_origin_protection="auto")
+    return TestClient(app, base_url=f"http://{LOOPBACK}")
+
+
+def test_logger_is_outside_the_guard(client) -> None:
+    """The guard is the outermost FastMCP middleware; ours has to sit outside it to see 421/403."""
+    assert client.app.user_middleware[0].cls is GuardRejectionLoggingMiddleware
+
+
+def test_rejected_host_is_logged(client, caplog) -> None:
+    with caplog.at_level("WARNING"):
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
+
+    logged = caplog.text
+    assert "evil.example" in logged
+    assert "MATTERMOST_HTTP_ALLOWED_HOSTS" in logged
+
+
+def test_rejected_origin_is_logged(client, caplog) -> None:
+    with caplog.at_level("WARNING"):
+        response = client.get("/health", headers={"Origin": "https://evil.example"})
+        assert response.status_code == 403
+
+    logged = caplog.text
+    assert "https://evil.example" in logged
+    assert "MATTERMOST_HTTP_ALLOWED_ORIGINS" in logged
+
+
+def test_accepted_request_logs_nothing(client, caplog) -> None:
+    with caplog.at_level("WARNING"):
+        assert client.get("/health").status_code == 200
+
+    assert "Host/Origin protection" not in caplog.text
+
+
+def test_response_body_is_unchanged(client) -> None:
+    """Diagnostics go to the server log; the client learns nothing extra."""
+    response = client.get("/health", headers={"Host": "evil.example"})
+    assert response.text == "Misdirected Request"
+
+
+class TestConfiguredPostureReachesHttpApp:
+    """``mcp.http_app()`` with no keyword arguments must inherit the configured protection.
+
+    This is the path used by ``fastmcp run``, a standalone ASGI server, and this app mounted
+    into a parent application — none of which pass protection keyword arguments.
+    """
+
+    def test_unset_leaves_app_unprotected(self, mock_settings) -> None:
+        from mcp_server_mattermost.server import mcp
+
+        client = TestClient(mcp.http_app(), base_url=f"http://{LOOPBACK}")
+        assert client.get("/health", headers={"Host": "mcp.example.com"}).status_code == 200
+
+    def test_configured_protection_is_inherited(self, mock_settings, monkeypatch) -> None:
+        from mcp_server_mattermost.config import get_settings
+        from mcp_server_mattermost.server import mcp
+
+        monkeypatch.setenv("MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION", "auto")
+        get_settings.cache_clear()
+        apply_http_security_settings(get_settings())
+
+        client = TestClient(mcp.http_app(), base_url=f"http://{LOOPBACK}")
+        assert client.get("/health", headers={"Host": "mcp.example.com"}).status_code == 421
+
+    def test_configured_allowlist_is_inherited(self, mock_settings, monkeypatch) -> None:
+        from mcp_server_mattermost.config import get_settings
+        from mcp_server_mattermost.server import mcp
+
+        monkeypatch.setenv("MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION", "auto")
+        monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", "mcp.example.com")
+        get_settings.cache_clear()
+        apply_http_security_settings(get_settings())
+
+        client = TestClient(mcp.http_app(), base_url=f"http://{LOOPBACK}")
+        assert client.get("/health", headers={"Host": "mcp.example.com"}).status_code == 200

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -1,0 +1,85 @@
+"""Tests for HTTP transport-security guards."""
+
+import pytest
+
+from mcp_server_mattermost.config import AuthMode, Settings
+from mcp_server_mattermost.exceptions import ConfigurationError
+from mcp_server_mattermost.http_security import (
+    enforce_unauthenticated_http_policy,
+    is_loopback_host,
+    resolve_host_origin_kwargs,
+)
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {"url": "https://mm.example.com", "token": "SENTINEL-TOKEN"}
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.2", "::1", "localhost"])
+def test_is_loopback_true(host: str) -> None:
+    assert is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "10.0.0.5", "mcp.example.com", ""])  # noqa: S104
+def test_is_loopback_false(host: str) -> None:
+    assert is_loopback_host(host) is False
+
+
+def test_stdio_static_token_allowed() -> None:
+    assert enforce_unauthenticated_http_policy(_settings(), transport="stdio", host="0.0.0.0") is None  # noqa: S104
+
+
+def test_http_client_token_allowed() -> None:
+    settings = _settings(auth_mode=AuthMode.CLIENT_TOKEN, token=None)
+    assert enforce_unauthenticated_http_policy(settings, transport="http", host="0.0.0.0") is None  # noqa: S104
+
+
+def test_http_static_token_loopback_no_optin_refused() -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        enforce_unauthenticated_http_policy(_settings(), transport="http", host="127.0.0.1")
+    assert "MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP" in str(exc.value)
+
+
+def test_http_static_token_public_refused_even_with_optin() -> None:
+    settings = _settings(allow_unauthenticated_http=True)
+    with pytest.raises(ConfigurationError) as exc:
+        enforce_unauthenticated_http_policy(settings, transport="http", host="0.0.0.0")  # noqa: S104
+    assert "loopback" in str(exc.value).lower()
+
+
+def test_http_static_token_loopback_optin_warns() -> None:
+    settings = _settings(allow_unauthenticated_http=True)
+    warning = enforce_unauthenticated_http_policy(settings, transport="http", host="127.0.0.1")
+    assert warning is not None
+    assert "loopback" in warning.lower()
+
+
+def test_messages_never_leak_secrets() -> None:
+    settings = _settings(allow_unauthenticated_http=True)
+    warning = enforce_unauthenticated_http_policy(settings, transport="http", host="127.0.0.1")
+    assert warning is not None
+    assert "SENTINEL-TOKEN" not in warning
+    assert "Authorization" not in warning
+    for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
+        with pytest.raises(ConfigurationError) as exc:
+            enforce_unauthenticated_http_policy(_settings(), transport="http", host=host)
+        assert "SENTINEL-TOKEN" not in str(exc.value)
+        assert "Authorization" not in str(exc.value)
+
+
+def test_resolve_host_origin_kwargs_defaults() -> None:
+    assert resolve_host_origin_kwargs(_settings()) == {
+        "host_origin_protection": "auto",
+        "allowed_hosts": None,
+        "allowed_origins": None,
+    }
+
+
+def test_resolve_host_origin_kwargs_with_allowlists() -> None:
+    settings = _settings(http_allowed_hosts=["a.example"], http_allowed_origins=["https://a.example"])
+    kwargs = resolve_host_origin_kwargs(settings)
+    assert kwargs["host_origin_protection"] == "auto"
+    assert kwargs["allowed_hosts"] == ["a.example"]
+    assert kwargs["allowed_origins"] == ["https://a.example"]

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -3,11 +3,10 @@
 import pytest
 
 from mcp_server_mattermost.config import AuthMode, Settings
-from mcp_server_mattermost.exceptions import ConfigurationError
 from mcp_server_mattermost.http_security import (
-    enforce_unauthenticated_http_policy,
     is_loopback_host,
     resolve_host_origin_kwargs,
+    unauthenticated_http_warning,
 )
 
 
@@ -27,46 +26,44 @@ def test_is_loopback_false(host: str) -> None:
     assert is_loopback_host(host) is False
 
 
-def test_stdio_static_token_allowed() -> None:
-    assert enforce_unauthenticated_http_policy(_settings(), transport="stdio", host="0.0.0.0") is None  # noqa: S104
+def test_stdio_static_token_no_warning() -> None:
+    assert unauthenticated_http_warning(_settings(), transport="stdio", host="0.0.0.0") is None  # noqa: S104
 
 
-def test_http_client_token_allowed() -> None:
+def test_http_client_token_no_warning() -> None:
     settings = _settings(auth_mode=AuthMode.CLIENT_TOKEN, token=None)
-    assert enforce_unauthenticated_http_policy(settings, transport="http", host="0.0.0.0") is None  # noqa: S104
+    assert unauthenticated_http_warning(settings, transport="http", host="0.0.0.0") is None  # noqa: S104
 
 
-def test_http_static_token_loopback_no_optin_refused() -> None:
-    with pytest.raises(ConfigurationError) as exc:
-        enforce_unauthenticated_http_policy(_settings(), transport="http", host="127.0.0.1")
-    assert "MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP" in str(exc.value)
-
-
-def test_http_static_token_public_refused_even_with_optin() -> None:
-    settings = _settings(allow_unauthenticated_http=True)
-    with pytest.raises(ConfigurationError) as exc:
-        enforce_unauthenticated_http_policy(settings, transport="http", host="0.0.0.0")  # noqa: S104
-    assert "loopback" in str(exc.value).lower()
-
-
-def test_http_static_token_loopback_optin_warns() -> None:
-    settings = _settings(allow_unauthenticated_http=True)
-    warning = enforce_unauthenticated_http_policy(settings, transport="http", host="127.0.0.1")
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+def test_http_static_token_loopback_warns(host: str) -> None:
+    warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
     assert warning is not None
     assert "loopback" in warning.lower()
 
 
-def test_messages_never_leak_secrets() -> None:
-    settings = _settings(allow_unauthenticated_http=True)
-    warning = enforce_unauthenticated_http_policy(settings, transport="http", host="127.0.0.1")
+def test_http_static_token_public_warns() -> None:
+    """Non-loopback no longer refuses to start — it returns a louder warning instead."""
+    warning = unauthenticated_http_warning(_settings(), transport="http", host="0.0.0.0")  # noqa: S104
     assert warning is not None
-    assert "SENTINEL-TOKEN" not in warning
-    assert "Authorization" not in warning
+    assert "0.0.0.0" in warning  # noqa: S104
+    assert "client_token" in warning
+
+
+def test_guard_does_not_reference_removed_env_var() -> None:
+    """The MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP opt-in was removed; no message should mention it."""
     for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
-        with pytest.raises(ConfigurationError) as exc:
-            enforce_unauthenticated_http_policy(_settings(), transport="http", host=host)
-        assert "SENTINEL-TOKEN" not in str(exc.value)
-        assert "Authorization" not in str(exc.value)
+        warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
+        assert warning is not None
+        assert "ALLOW_UNAUTHENTICATED_HTTP" not in warning
+
+
+def test_messages_never_leak_secrets() -> None:
+    for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
+        warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
+        assert warning is not None
+        assert "SENTINEL-TOKEN" not in warning
+        assert "Authorization" not in warning
 
 
 def test_resolve_host_origin_kwargs_defaults() -> None:

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -4,6 +4,7 @@ import pytest
 
 from mcp_server_mattermost.config import AuthMode, Settings
 from mcp_server_mattermost.http_security import (
+    host_origin_posture,
     is_loopback_host,
     resolve_host_origin_kwargs,
     unauthenticated_http_warning,
@@ -64,6 +65,37 @@ def test_messages_never_leak_secrets() -> None:
         assert warning is not None
         assert "SENTINEL-TOKEN" not in warning
         assert "Authorization" not in warning
+
+
+def test_warning_describes_protection_per_connection_not_per_bind() -> None:
+    """The non-loopback warning must not claim protection is off for the bind as a whole."""
+    warning = unauthenticated_http_warning(_settings(), transport="http", host="0.0.0.0")  # noqa: S104
+    assert warning is not None
+    assert "per connection" in warning
+    assert "for this bind" not in warning
+
+
+def test_posture_reports_absent_allowlists() -> None:
+    posture = host_origin_posture(_settings())
+    assert "allowed_hosts=[]" in posture
+    assert "allowed_origins=[]" in posture
+    assert "arrives on" in posture
+
+
+def test_posture_reports_configured_allowlists() -> None:
+    settings = _settings(
+        http_allowed_hosts=["a.example", "b.example"],
+        http_allowed_origins=["https://a.example"],
+    )
+    posture = host_origin_posture(settings)
+    assert "allowed_hosts=[a.example, b.example]" in posture
+    assert "allowed_origins=[https://a.example]" in posture
+
+
+def test_posture_never_leaks_secrets() -> None:
+    posture = host_origin_posture(_settings())
+    assert "SENTINEL-TOKEN" not in posture
+    assert "Authorization" not in posture
 
 
 def test_resolve_host_origin_kwargs_defaults() -> None:

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -1,14 +1,26 @@
-"""Tests for HTTP transport-security guards."""
+"""Tests for HTTP transport-security posture and advisories."""
 
+import fastmcp
 import pytest
+from fastmcp.server.http import _is_loopback_host as fastmcp_is_loopback_host
 
-from mcp_server_mattermost.config import AuthMode, Settings
+from mcp_server_mattermost.config import AuthMode, HostOriginProtection, Settings
 from mcp_server_mattermost.http_security import (
+    apply_http_security_settings,
+    effective_protection,
     host_origin_posture,
+    inert_allowlist_warning,
     is_loopback_host,
-    resolve_host_origin_kwargs,
     unauthenticated_http_warning,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fastmcp_settings(monkeypatch):
+    """Keep writes to FastMCP's global settings from leaking between tests."""
+    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", False)
+    monkeypatch.setattr(fastmcp.settings, "http_allowed_hosts", None)
+    monkeypatch.setattr(fastmcp.settings, "http_allowed_origins", None)
 
 
 def _settings(**overrides: object) -> Settings:
@@ -27,88 +39,153 @@ def test_is_loopback_false(host: str) -> None:
     assert is_loopback_host(host) is False
 
 
-def test_stdio_static_token_no_warning() -> None:
-    assert unauthenticated_http_warning(_settings(), transport="stdio", host="0.0.0.0") is None  # noqa: S104
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "[::1]", "LocalHost", "127.0.0.1 ", "127.0.0.1:8000", "[::1]:8000", "0.0.0.0", "example.com", ""],  # noqa: S104
+)
+def test_is_loopback_matches_fastmcp(host: str) -> None:
+    """Our classification drives the warnings; FastMCP's drives the actual guard.
+
+    They must agree, or the warnings describe a posture the server is not applying.
+    """
+    assert is_loopback_host(host) is fastmcp_is_loopback_host(host)
 
 
-def test_http_client_token_no_warning() -> None:
-    settings = _settings(auth_mode=AuthMode.CLIENT_TOKEN, token=None)
-    assert unauthenticated_http_warning(settings, transport="http", host="0.0.0.0") is None  # noqa: S104
+class TestUnauthenticatedWarning:
+    def test_stdio_static_token_no_warning(self) -> None:
+        assert unauthenticated_http_warning(_settings(), transport="stdio", host="0.0.0.0") is None  # noqa: S104
 
+    def test_http_client_token_no_warning(self) -> None:
+        settings = _settings(auth_mode=AuthMode.CLIENT_TOKEN, token=None)
+        assert unauthenticated_http_warning(settings, transport="http", host="0.0.0.0") is None  # noqa: S104
 
-@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
-def test_http_static_token_loopback_warns(host: str) -> None:
-    warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
-    assert warning is not None
-    assert "loopback" in warning.lower()
-
-
-def test_http_static_token_public_warns() -> None:
-    """Non-loopback no longer refuses to start — it returns a louder warning instead."""
-    warning = unauthenticated_http_warning(_settings(), transport="http", host="0.0.0.0")  # noqa: S104
-    assert warning is not None
-    assert "0.0.0.0" in warning  # noqa: S104
-    assert "client_token" in warning
-
-
-def test_guard_does_not_reference_removed_env_var() -> None:
-    """The MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP opt-in was removed; no message should mention it."""
-    for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+    def test_http_static_token_loopback_warns(self, host: str) -> None:
         warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
         assert warning is not None
-        assert "ALLOW_UNAUTHENTICATED_HTTP" not in warning
+        assert "loopback" in warning.lower()
 
-
-def test_messages_never_leak_secrets() -> None:
-    for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
-        warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
+    def test_http_static_token_public_warns(self) -> None:
+        warning = unauthenticated_http_warning(_settings(), transport="http", host="0.0.0.0")  # noqa: S104
         assert warning is not None
-        assert "SENTINEL-TOKEN" not in warning
-        assert "Authorization" not in warning
+        assert "0.0.0.0" in warning  # noqa: S104
+        assert "client_token" in warning
+
+    def test_guard_does_not_reference_removed_env_var(self) -> None:
+        for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
+            warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
+            assert warning is not None
+            assert "ALLOW_UNAUTHENTICATED_HTTP" not in warning
+
+    def test_messages_never_leak_secrets(self) -> None:
+        for host in ("127.0.0.1", "0.0.0.0"):  # noqa: S104
+            warning = unauthenticated_http_warning(_settings(), transport="http", host=host)
+            assert warning is not None
+            assert "SENTINEL-TOKEN" not in warning
+            assert "Authorization" not in warning
 
 
-def test_warning_describes_protection_per_connection_not_per_bind() -> None:
-    """The non-loopback warning must not claim protection is off for the bind as a whole."""
-    warning = unauthenticated_http_warning(_settings(), transport="http", host="0.0.0.0")  # noqa: S104
-    assert warning is not None
-    assert "per connection" in warning
-    assert "for this bind" not in warning
+class TestApplyHttpSecuritySettings:
+    def test_unset_leaves_fastmcp_settings_alone(self) -> None:
+        """An operator's own FASTMCP_HTTP_HOST_ORIGIN_PROTECTION must survive."""
+        fastmcp.settings.http_host_origin_protection = True
+        apply_http_security_settings(_settings())
+        assert fastmcp.settings.http_host_origin_protection is True
+        assert effective_protection() is HostOriginProtection.STRICT
 
-
-def test_posture_reports_absent_allowlists() -> None:
-    posture = host_origin_posture(_settings())
-    assert "allowed_hosts=[]" in posture
-    assert "allowed_origins=[]" in posture
-    assert "arrives on" in posture
-
-
-def test_posture_reports_configured_allowlists() -> None:
-    settings = _settings(
-        http_allowed_hosts=["a.example", "b.example"],
-        http_allowed_origins=["https://a.example"],
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [("off", False), ("auto", "auto"), ("strict", True)],
     )
-    posture = host_origin_posture(settings)
-    assert "allowed_hosts=[a.example, b.example]" in posture
-    assert "allowed_origins=[https://a.example]" in posture
+    def test_configured_level_is_written(self, configured: str, expected: object) -> None:
+        apply_http_security_settings(_settings(http_host_origin_protection=configured))
+        assert fastmcp.settings.http_host_origin_protection == expected
+
+    def test_off_overrides_fastmcp_env_var(self) -> None:
+        fastmcp.settings.http_host_origin_protection = "auto"
+        apply_http_security_settings(_settings(http_host_origin_protection="off"))
+        assert fastmcp.settings.http_host_origin_protection is False
+
+    def test_allowlists_are_written(self) -> None:
+        settings = _settings(
+            http_allowed_hosts=["a.example"],
+            http_allowed_origins=["https://a.example"],
+        )
+        apply_http_security_settings(settings)
+        assert fastmcp.settings.http_allowed_hosts == ["a.example"]
+        assert fastmcp.settings.http_allowed_origins == ["https://a.example"]
+
+    def test_absent_allowlists_leave_fastmcp_settings_alone(self) -> None:
+        fastmcp.settings.http_allowed_hosts = ["preset.example"]
+        apply_http_security_settings(_settings())
+        assert fastmcp.settings.http_allowed_hosts == ["preset.example"]
 
 
-def test_posture_never_leaks_secrets() -> None:
-    posture = host_origin_posture(_settings())
-    assert "SENTINEL-TOKEN" not in posture
-    assert "Authorization" not in posture
+class TestPosture:
+    def test_off_by_default(self) -> None:
+        posture = host_origin_posture(_settings(), host="127.0.0.1")
+        assert "OFF" in posture
+        assert "MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION" in posture
+
+    def test_off_announces_the_coming_default_change(self) -> None:
+        """Operators who read neither the changelog nor the tracker still get warned in time."""
+        assert "1.0.0" in host_origin_posture(_settings(), host="127.0.0.1")
+
+    def test_loopback_bind_reports_unconditional_validation(self) -> None:
+        settings = _settings(http_host_origin_protection="auto")
+        apply_http_security_settings(settings)
+        posture = host_origin_posture(settings, host="127.0.0.1")
+        assert "mode=auto" in posture
+        assert "every connection" in posture
+        assert "MATTERMOST_HTTP_ALLOWED_HOSTS" in posture
+
+    def test_non_loopback_bind_reports_per_arrival_rule(self) -> None:
+        settings = _settings(http_host_origin_protection="auto")
+        apply_http_security_settings(settings)
+        posture = host_origin_posture(settings, host="0.0.0.0")  # noqa: S104
+        assert "mode=auto" in posture
+        assert "arrives on" in posture
+
+    def test_strict_reported(self) -> None:
+        settings = _settings(http_host_origin_protection="strict")
+        apply_http_security_settings(settings)
+        assert "mode=strict" in host_origin_posture(settings, host="0.0.0.0")  # noqa: S104
+
+    def test_absent_allowlist_is_distinguishable_from_empty(self) -> None:
+        """``None`` and ``[]`` mean opposite things to FastMCP, so they must not print alike."""
+        settings = _settings(http_host_origin_protection="auto")
+        apply_http_security_settings(settings)
+        assert "allowed_hosts=None" in host_origin_posture(settings, host="0.0.0.0")  # noqa: S104
+
+    def test_configured_allowlists_reported(self) -> None:
+        settings = _settings(
+            http_host_origin_protection="auto",
+            http_allowed_hosts=["a.example", "b.example"],
+            http_allowed_origins=["https://a.example"],
+        )
+        apply_http_security_settings(settings)
+        posture = host_origin_posture(settings, host="0.0.0.0")  # noqa: S104
+        assert "allowed_hosts=['a.example', 'b.example']" in posture
+        assert "allowed_origins=['https://a.example']" in posture
+
+    def test_never_leaks_secrets(self) -> None:
+        posture = host_origin_posture(_settings(), host="127.0.0.1")
+        assert "SENTINEL-TOKEN" not in posture
+        assert "Authorization" not in posture
 
 
-def test_resolve_host_origin_kwargs_defaults() -> None:
-    assert resolve_host_origin_kwargs(_settings()) == {
-        "host_origin_protection": "auto",
-        "allowed_hosts": None,
-        "allowed_origins": None,
-    }
+class TestInertAllowlistWarning:
+    def test_warns_when_allowlist_set_but_protection_off(self) -> None:
+        settings = _settings(http_allowed_hosts=["a.example"])
+        apply_http_security_settings(settings)
+        warning = inert_allowlist_warning(settings)
+        assert warning is not None
+        assert "no effect" in warning
 
+    def test_silent_when_protection_enabled(self) -> None:
+        settings = _settings(http_host_origin_protection="auto", http_allowed_hosts=["a.example"])
+        apply_http_security_settings(settings)
+        assert inert_allowlist_warning(settings) is None
 
-def test_resolve_host_origin_kwargs_with_allowlists() -> None:
-    settings = _settings(http_allowed_hosts=["a.example"], http_allowed_origins=["https://a.example"])
-    kwargs = resolve_host_origin_kwargs(settings)
-    assert kwargs["host_origin_protection"] == "auto"
-    assert kwargs["allowed_hosts"] == ["a.example"]
-    assert kwargs["allowed_origins"] == ["https://a.example"]
+    def test_silent_without_allowlists(self) -> None:
+        assert inert_allowlist_warning(_settings()) is None

--- a/tests/test_http_transport_security.py
+++ b/tests/test_http_transport_security.py
@@ -1,0 +1,41 @@
+"""Behavioral tests for FastMCP Host/Origin (DNS-rebinding) protection."""
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def guard_client(mock_settings):
+    """TestClient over the HTTP app with auto protection and explicit allowlists."""
+    from mcp_server_mattermost.server import mcp
+
+    app = mcp.http_app(
+        host_origin_protection="auto",
+        allowed_hosts=["good.example"],
+        allowed_origins=["https://good.example"],
+    )
+    return TestClient(app)
+
+
+def test_allowed_host_passes(guard_client) -> None:
+    response = guard_client.get("/health", headers={"Host": "good.example"})
+    assert response.status_code == 200
+
+
+def test_foreign_host_rejected(guard_client) -> None:
+    response = guard_client.get("/health", headers={"Host": "evil.example"})
+    assert response.status_code == 421
+
+
+def test_foreign_origin_rejected(guard_client) -> None:
+    response = guard_client.get(
+        "/health",
+        headers={"Host": "good.example", "Origin": "https://evil.example"},
+    )
+    assert response.status_code == 403
+
+
+def test_missing_origin_passes(guard_client) -> None:
+    # Non-browser MCP clients send no Origin; they must not be blocked.
+    response = guard_client.get("/health", headers={"Host": "good.example"})
+    assert response.status_code == 200

--- a/tests/test_http_transport_security.py
+++ b/tests/test_http_transport_security.py
@@ -39,3 +39,32 @@ def test_missing_origin_passes(guard_client) -> None:
     # Non-browser MCP clients send no Origin; they must not be blocked.
     response = guard_client.get("/health", headers={"Host": "good.example"})
     assert response.status_code == 200
+
+
+@pytest.fixture
+def default_path_client(mock_settings):
+    """TestClient over the HTTP app with auto protection and NO allowlist.
+
+    This mirrors the shipping default: a loopback bind with no explicit
+    allowed_hosts/allowed_origins, relying on FastMCP's "auto" mode to detect
+    the loopback bind and validate Host against its built-in defaults
+    (127.0.0.1, localhost, ::1).
+
+    The TestClient base_url is overridden to a loopback address so the
+    server's bound host is loopback, which is what triggers "auto"
+    validation (the default base_url of http://testserver is non-loopback).
+    """
+    from mcp_server_mattermost.server import mcp
+
+    app = mcp.http_app(host_origin_protection="auto")
+    return TestClient(app, base_url="http://127.0.0.1")
+
+
+def test_default_path_loopback_host_passes(default_path_client) -> None:
+    response = default_path_client.get("/health", headers={"Host": "127.0.0.1"})
+    assert response.status_code == 200
+
+
+def test_default_path_foreign_host_rejected(default_path_client) -> None:
+    response = default_path_client.get("/health", headers={"Host": "evil.example"})
+    assert response.status_code == 421

--- a/tests/test_http_transport_security.py
+++ b/tests/test_http_transport_security.py
@@ -7,8 +7,9 @@ reaching it through a LAN address. These tests drive that distinction through th
 ``base_url``, which is what populates ``scope["server"]``.
 
 The bind address cannot be exercised from here: ``mcp.http_app()`` never receives one. Only
-``mcp.run()`` does, where FastMCP additionally pins an allowlist for a loopback bind. Our side
-of that contract — the kwargs handed to ``mcp.run()`` — is asserted in ``tests/test_init.py``.
+``mcp.run()`` does, where FastMCP additionally pins an allowlist for a loopback bind. These tests
+pass the protection level explicitly; that it is also picked up from configuration on every
+entry point is asserted in ``tests/test_http_security.py``.
 """
 
 import fastmcp
@@ -66,8 +67,8 @@ class TestLoopbackArrival:
 class TestNonLoopbackArrival:
     """A connection arriving on a LAN address is unvalidated until an allowlist exists.
 
-    This is the ISSUE-001 configuration: one process bound to 0.0.0.0 accepts these headers on
-    its LAN address while rejecting the very same headers on 127.0.0.1.
+    One process bound to 0.0.0.0 therefore accepts these headers on its LAN address while
+    rejecting the very same headers on 127.0.0.1.
     """
 
     @pytest.fixture

--- a/tests/test_http_transport_security.py
+++ b/tests/test_http_transport_security.py
@@ -1,70 +1,156 @@
-"""Behavioral tests for FastMCP Host/Origin (DNS-rebinding) protection."""
+"""Behavioral tests for FastMCP Host/Origin (DNS-rebinding) protection.
 
+Protection is decided per connection, from the local address the connection arrived on
+(``scope["server"][0]``) — not from the address the server is bound to. A server bound to
+``0.0.0.0`` therefore validates a request reaching it through ``127.0.0.1`` and skips one
+reaching it through a LAN address. These tests drive that distinction through the TestClient
+``base_url``, which is what populates ``scope["server"]``.
+
+The bind address cannot be exercised from here: ``mcp.http_app()`` never receives one. Only
+``mcp.run()`` does, where FastMCP additionally pins an allowlist for a loopback bind. Our side
+of that contract — the kwargs handed to ``mcp.run()`` — is asserted in ``tests/test_init.py``.
+"""
+
+import fastmcp
 import pytest
 from starlette.testclient import TestClient
 
 
-@pytest.fixture
-def guard_client(mock_settings):
-    """TestClient over the HTTP app with auto protection and explicit allowlists."""
-    from mcp_server_mattermost.server import mcp
-
-    app = mcp.http_app(
-        host_origin_protection="auto",
-        allowed_hosts=["good.example"],
-        allowed_origins=["https://good.example"],
-    )
-    return TestClient(app)
-
-
-def test_allowed_host_passes(guard_client) -> None:
-    response = guard_client.get("/health", headers={"Host": "good.example"})
-    assert response.status_code == 200
-
-
-def test_foreign_host_rejected(guard_client) -> None:
-    response = guard_client.get("/health", headers={"Host": "evil.example"})
-    assert response.status_code == 421
-
-
-def test_foreign_origin_rejected(guard_client) -> None:
-    response = guard_client.get(
-        "/health",
-        headers={"Host": "good.example", "Origin": "https://evil.example"},
-    )
-    assert response.status_code == 403
-
-
-def test_missing_origin_passes(guard_client) -> None:
-    # Non-browser MCP clients send no Origin; they must not be blocked.
-    response = guard_client.get("/health", headers={"Host": "good.example"})
-    assert response.status_code == 200
+LOOPBACK = "127.0.0.1:8020"
+LAN = "192.0.2.10:8020"  # RFC 5737 documentation range
 
 
 @pytest.fixture
-def default_path_client(mock_settings):
-    """TestClient over the HTTP app with auto protection and NO allowlist.
+def arrival_client(mock_settings, monkeypatch):
+    """Return a factory for TestClients whose connections arrive on a chosen local address."""
+    # http_app() falls back to the global FastMCP settings for unset allowlists, and those read
+    # FASTMCP_HTTP_ALLOWED_* plus any .env file. Pin them so a developer's environment cannot
+    # shift a request into a different row of the matrix below.
+    monkeypatch.setattr(fastmcp.settings, "http_allowed_hosts", None)
+    monkeypatch.setattr(fastmcp.settings, "http_allowed_origins", None)
 
-    This mirrors the shipping default: a loopback bind with no explicit
-    allowed_hosts/allowed_origins, relying on FastMCP's "auto" mode to detect
-    the loopback bind and validate Host against its built-in defaults
-    (127.0.0.1, localhost, ::1).
+    def _build(*, arrives_on, allowed_hosts=None, allowed_origins=None):
+        from mcp_server_mattermost.server import mcp
 
-    The TestClient base_url is overridden to a loopback address so the
-    server's bound host is loopback, which is what triggers "auto"
-    validation (the default base_url of http://testserver is non-loopback).
+        app = mcp.http_app(
+            host_origin_protection="auto",
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
+        return TestClient(app, base_url=f"http://{arrives_on}")
+
+    return _build
+
+
+class TestLoopbackArrival:
+    """A connection arriving on loopback is validated even with no allowlist configured."""
+
+    @pytest.fixture
+    def client(self, arrival_client):
+        return arrival_client(arrives_on=LOOPBACK)
+
+    def test_arrival_address_as_host_passes(self, client) -> None:
+        assert client.get("/health").status_code == 200
+
+    def test_foreign_host_rejected(self, client) -> None:
+        assert client.get("/health", headers={"Host": "legacy-client.example"}).status_code == 421
+
+    def test_foreign_origin_rejected(self, client) -> None:
+        assert client.get("/health", headers={"Origin": "https://legacy-client.example"}).status_code == 403
+
+    def test_loopback_origin_passes(self, client) -> None:
+        # Any loopback Origin is accepted while Host is loopback, whatever the port.
+        assert client.get("/health", headers={"Origin": f"http://{LOOPBACK}"}).status_code == 200
+
+
+class TestNonLoopbackArrival:
+    """A connection arriving on a LAN address is unvalidated until an allowlist exists.
+
+    This is the ISSUE-001 configuration: one process bound to 0.0.0.0 accepts these headers on
+    its LAN address while rejecting the very same headers on 127.0.0.1.
     """
-    from mcp_server_mattermost.server import mcp
 
-    app = mcp.http_app(host_origin_protection="auto")
-    return TestClient(app, base_url="http://127.0.0.1")
+    @pytest.fixture
+    def client(self, arrival_client):
+        return arrival_client(arrives_on=LAN)
+
+    def test_foreign_host_passes(self, client) -> None:
+        assert client.get("/health", headers={"Host": "legacy-client.example"}).status_code == 200
+
+    def test_foreign_origin_passes(self, client) -> None:
+        assert client.get("/health", headers={"Origin": "https://legacy-client.example"}).status_code == 200
 
 
-def test_default_path_loopback_host_passes(default_path_client) -> None:
-    response = default_path_client.get("/health", headers={"Host": "127.0.0.1"})
-    assert response.status_code == 200
+class TestAllowedHostsOffLoopback:
+    """MATTERMOST_HTTP_ALLOWED_HOSTS turns on both Host and Origin validation on every interface."""
+
+    @pytest.fixture
+    def client(self, arrival_client):
+        return arrival_client(arrives_on=LAN, allowed_hosts=["good.example"])
+
+    def test_listed_host_passes(self, client) -> None:
+        assert client.get("/health", headers={"Host": "good.example"}).status_code == 200
+
+    def test_unlisted_host_rejected(self, client) -> None:
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
+
+    def test_origin_validated_too(self, client) -> None:
+        response = client.get("/health", headers={"Host": "good.example", "Origin": "https://evil.example"})
+        assert response.status_code == 403
+
+    def test_arrival_address_as_host_passes(self, client) -> None:
+        assert client.get("/health", headers={"Host": LAN}).status_code == 200
 
 
-def test_default_path_foreign_host_rejected(default_path_client) -> None:
-    response = default_path_client.get("/health", headers={"Host": "evil.example"})
-    assert response.status_code == 421
+class TestAllowedOriginsOnlyOffLoopback:
+    """MATTERMOST_HTTP_ALLOWED_ORIGINS alone validates Origin but leaves Host unvalidated."""
+
+    @pytest.fixture
+    def client(self, arrival_client):
+        return arrival_client(arrives_on=LAN, allowed_origins=["https://good.example"])
+
+    def test_host_still_unvalidated(self, client) -> None:
+        # The asymmetry: an origins-only allowlist does not extend Host validation off-loopback.
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 200
+
+    def test_listed_origin_passes(self, client) -> None:
+        assert client.get("/health", headers={"Origin": "https://good.example"}).status_code == 200
+
+    def test_unlisted_origin_rejected(self, client) -> None:
+        assert client.get("/health", headers={"Origin": "https://evil.example"}).status_code == 403
+
+    def test_missing_origin_passes(self, client) -> None:
+        # Non-browser MCP clients send no Origin; they must not be blocked.
+        assert client.get("/health").status_code == 200
+
+    def test_same_origin_rejected_off_loopback(self, client) -> None:
+        # Documented footgun: an origins-only allowlist drops the same-origin exemption here.
+        assert client.get("/health", headers={"Origin": f"http://{LAN}"}).status_code == 403
+
+    def test_same_origin_passes_on_loopback_arrival(self, arrival_client) -> None:
+        # Contrast with the case above: a loopback arrival keeps the same-origin exemption.
+        client = arrival_client(arrives_on=LOOPBACK, allowed_origins=["https://good.example"])
+        assert client.get("/health", headers={"Origin": f"http://{LOOPBACK}"}).status_code == 200
+
+
+class TestBothAllowlistsOffLoopback:
+    """The configuration the docs recommend behind a reverse proxy: both allowlists declared."""
+
+    @pytest.fixture
+    def client(self, arrival_client):
+        return arrival_client(
+            arrives_on=LAN,
+            allowed_hosts=["good.example"],
+            allowed_origins=["https://good.example"],
+        )
+
+    def test_listed_host_and_origin_pass(self, client) -> None:
+        response = client.get("/health", headers={"Host": "good.example", "Origin": "https://good.example"})
+        assert response.status_code == 200
+
+    def test_unlisted_host_rejected(self, client) -> None:
+        assert client.get("/health", headers={"Host": "evil.example"}).status_code == 421
+
+    def test_unlisted_origin_rejected(self, client) -> None:
+        response = client.get("/health", headers={"Host": "good.example", "Origin": "https://evil.example"})
+        assert response.status_code == 403

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,8 @@
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestMain:
     """Tests for main() entry point."""
@@ -26,12 +28,16 @@ class TestMain:
 
             mock_mcp.run.assert_called_once_with(transport="stdio")
 
-    def test_main_with_http_flag(self) -> None:
-        """Test that --http flag uses http transport."""
-        with (
-            patch.object(sys, "argv", ["mcp-server-mattermost", "--http"]),
-            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
-        ):
+    def test_main_with_http_flag(self, monkeypatch) -> None:
+        """--http uses http transport with Host/Origin protection."""
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http"])
+
+        with patch("mcp_server_mattermost.server.mcp") as mock_mcp:
             mock_mcp.run = MagicMock()
             from mcp_server_mattermost import main
 
@@ -42,32 +48,40 @@ class TestMain:
                 host="127.0.0.1",
                 port=8000,
                 uvicorn_config={"ws": "wsproto"},
+                host_origin_protection="auto",
+                allowed_hosts=None,
+                allowed_origins=None,
             )
+        get_settings.cache_clear()
 
-    def test_main_with_custom_port(self) -> None:
-        """Test that --port flag is respected."""
-        with (
-            patch.object(sys, "argv", ["mcp-server-mattermost", "--http", "--port", "9000"]),
-            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
-        ):
+    def test_main_with_custom_port(self, monkeypatch) -> None:
+        """--port is respected on the http run call."""
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--port", "9000"])
+
+        with patch("mcp_server_mattermost.server.mcp") as mock_mcp:
             mock_mcp.run = MagicMock()
             from mcp_server_mattermost import main
 
             main()
 
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="127.0.0.1",
-                port=9000,
-                uvicorn_config={"ws": "wsproto"},
-            )
+            assert mock_mcp.run.call_args[1]["port"] == 9000
+        get_settings.cache_clear()
 
-    def test_main_with_custom_host(self) -> None:
-        """Test that --host flag is respected."""
-        with (
-            patch.object(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"]),  # noqa: S104
-            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
-        ):
+    def test_main_with_custom_host(self, monkeypatch) -> None:
+        """--host flag is respected under the client_token auth mode."""
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
+
+        with patch("mcp_server_mattermost.server.mcp") as mock_mcp:
             mock_mcp.run = MagicMock()
             from mcp_server_mattermost import main
 
@@ -78,7 +92,101 @@ class TestMain:
                 host="0.0.0.0",  # noqa: S104
                 port=8000,
                 uvicorn_config={"ws": "wsproto"},
+                host_origin_protection="auto",
+                allowed_hosts=None,
+                allowed_origins=None,
             )
+        get_settings.cache_clear()
+
+
+class TestHttpTransportSecurity:
+    """main() fail-closed guard for unauthenticated HTTP."""
+
+    def test_http_static_token_no_optin_refuses(self, monkeypatch) -> None:
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "127.0.0.1"])
+
+        from mcp_server_mattermost import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert "MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP" in str(exc.value)
+        get_settings.cache_clear()
+
+    def test_http_static_token_public_refuses_even_with_optin(self, monkeypatch) -> None:
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+        monkeypatch.setenv("MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP", "true")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
+
+        from mcp_server_mattermost import main
+
+        with pytest.raises(SystemExit):
+            main()
+        get_settings.cache_clear()
+
+    def test_http_static_token_loopback_optin_runs_with_warning(self, monkeypatch) -> None:
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
+        monkeypatch.setenv("MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP", "true")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "127.0.0.1"])
+
+        with (
+            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
+            patch("mcp_server_mattermost.logging.logger") as mock_logger,
+            patch("mcp_server_mattermost.logging.setup_logging"),
+        ):
+            mock_mcp.run = MagicMock()
+            from mcp_server_mattermost import main
+
+            main()
+
+            mock_mcp.run.assert_called_once_with(
+                transport="http",
+                host="127.0.0.1",
+                port=8000,
+                uvicorn_config={"ws": "wsproto"},
+                host_origin_protection="auto",
+                allowed_hosts=None,
+                allowed_origins=None,
+            )
+            mock_logger.warning.assert_called_once()
+        get_settings.cache_clear()
+
+    def test_http_client_token_runs_without_optin(self, monkeypatch) -> None:
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
+
+        with patch("mcp_server_mattermost.server.mcp") as mock_mcp:
+            mock_mcp.run = MagicMock()
+            from mcp_server_mattermost import main
+
+            main()
+
+            mock_mcp.run.assert_called_once_with(
+                transport="http",
+                host="0.0.0.0",  # noqa: S104
+                port=8000,
+                uvicorn_config={"ws": "wsproto"},
+                host_origin_protection="auto",
+                allowed_hosts=None,
+                allowed_origins=None,
+            )
+        get_settings.cache_clear()
 
 
 class TestVersion:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,8 +3,6 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestMain:
     """Tests for main() entry point."""
@@ -128,45 +126,44 @@ class TestMain:
 
 
 class TestHttpTransportSecurity:
-    """main() fail-closed guard for unauthenticated HTTP."""
+    """main() guard for unauthenticated HTTP: warn (never refuse), louder off-loopback."""
 
-    def test_http_static_token_no_optin_refuses(self, monkeypatch) -> None:
+    def test_http_static_token_public_runs_with_warning(self, monkeypatch) -> None:
         from mcp_server_mattermost.config import get_settings
 
         get_settings.cache_clear()
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
-        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "127.0.0.1"])
-
-        from mcp_server_mattermost import main
-
-        with pytest.raises(SystemExit) as exc:
-            main()
-        assert "MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP" in str(exc.value)
-        get_settings.cache_clear()
-
-    def test_http_static_token_public_refuses_even_with_optin(self, monkeypatch) -> None:
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
-        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
-        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
-        monkeypatch.setenv("MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP", "true")
         monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
 
-        from mcp_server_mattermost import main
+        with (
+            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
+            patch("mcp_server_mattermost.logging.logger") as mock_logger,
+            patch("mcp_server_mattermost.logging.setup_logging"),
+        ):
+            mock_mcp.run = MagicMock()
+            from mcp_server_mattermost import main
 
-        with pytest.raises(SystemExit):
             main()
+
+            mock_mcp.run.assert_called_once_with(
+                transport="http",
+                host="0.0.0.0",  # noqa: S104
+                port=8000,
+                uvicorn_config={"ws": "wsproto"},
+                host_origin_protection="auto",
+                allowed_hosts=None,
+                allowed_origins=None,
+            )
+            mock_logger.warning.assert_called_once()
         get_settings.cache_clear()
 
-    def test_http_static_token_loopback_optin_runs_with_warning(self, monkeypatch) -> None:
+    def test_http_static_token_loopback_runs_with_warning(self, monkeypatch) -> None:
         from mcp_server_mattermost.config import get_settings
 
         get_settings.cache_clear()
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
-        monkeypatch.setenv("MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP", "true")
         monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "127.0.0.1"])
 
         with (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -54,6 +54,34 @@ class TestMain:
             )
         get_settings.cache_clear()
 
+    def test_main_http_allowlists_flow_to_run(self, monkeypatch) -> None:
+        """Non-empty MATTERMOST_HTTP_ALLOWED_* env values reach mcp.run()."""
+        from mcp_server_mattermost.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
+        monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", "good.example, other.example")
+        monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_ORIGINS", '["https://good.example"]')
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http"])
+
+        with patch("mcp_server_mattermost.server.mcp") as mock_mcp:
+            mock_mcp.run = MagicMock()
+            from mcp_server_mattermost import main
+
+            main()
+
+            mock_mcp.run.assert_called_once_with(
+                transport="http",
+                host="127.0.0.1",
+                port=8000,
+                uvicorn_config={"ws": "wsproto"},
+                host_origin_protection="auto",
+                allowed_hosts=["good.example", "other.example"],
+                allowed_origins=["https://good.example"],
+            )
+        get_settings.cache_clear()
+
     def test_main_with_custom_port(self, monkeypatch) -> None:
         """--port is respected on the http run call."""
         from mcp_server_mattermost.config import get_settings

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,25 @@
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+
+HTTP_RUN_KWARGS = {
+    "transport": "http",
+    "port": 8000,
+    "uvicorn_config": {"ws": "wsproto"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    """Drop the cached Settings around every test, including failing ones."""
+    from mcp_server_mattermost.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
 
 class TestMain:
     """Tests for main() entry point."""
@@ -13,7 +32,7 @@ class TestMain:
 
         assert callable(main)
 
-    def test_main_with_no_args_uses_stdio(self) -> None:
+    def test_main_with_no_args_uses_stdio(self, mock_settings) -> None:
         """Test that main() defaults to stdio transport."""
         with (
             patch.object(sys, "argv", ["mcp-server-mattermost"]),
@@ -27,10 +46,7 @@ class TestMain:
             mock_mcp.run.assert_called_once_with(transport="stdio")
 
     def test_main_with_http_flag(self, monkeypatch) -> None:
-        """--http uses http transport with Host/Origin protection."""
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
+        """--http uses http transport and leaves the security posture to FastMCP settings."""
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http"])
@@ -41,22 +57,14 @@ class TestMain:
 
             main()
 
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="127.0.0.1",
-                port=8000,
-                uvicorn_config={"ws": "wsproto"},
-                host_origin_protection="auto",
-                allowed_hosts=None,
-                allowed_origins=None,
-            )
-        get_settings.cache_clear()
+            mock_mcp.run.assert_called_once_with(host="127.0.0.1", **HTTP_RUN_KWARGS)
 
-    def test_main_http_allowlists_flow_to_run(self, monkeypatch) -> None:
-        """Non-empty MATTERMOST_HTTP_ALLOWED_* env values reach mcp.run()."""
-        from mcp_server_mattermost.config import get_settings
+    def test_main_does_not_pass_protection_kwargs(self, monkeypatch) -> None:
+        """Protection reaches FastMCP through its settings, not through mcp.run().
 
-        get_settings.cache_clear()
+        Passing it here would apply it only to the console entry point, and would silently
+        override an operator's own FASTMCP_HTTP_HOST_ORIGIN_PROTECTION.
+        """
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", "good.example, other.example")
@@ -69,22 +77,13 @@ class TestMain:
 
             main()
 
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="127.0.0.1",
-                port=8000,
-                uvicorn_config={"ws": "wsproto"},
-                host_origin_protection="auto",
-                allowed_hosts=["good.example", "other.example"],
-                allowed_origins=["https://good.example"],
-            )
-        get_settings.cache_clear()
+            kwargs = mock_mcp.run.call_args[1]
+            assert "host_origin_protection" not in kwargs
+            assert "allowed_hosts" not in kwargs
+            assert "allowed_origins" not in kwargs
 
     def test_main_with_custom_port(self, monkeypatch) -> None:
         """--port is respected on the http run call."""
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--port", "9000"])
@@ -96,13 +95,9 @@ class TestMain:
             main()
 
             assert mock_mcp.run.call_args[1]["port"] == 9000
-        get_settings.cache_clear()
 
     def test_main_with_custom_host(self, monkeypatch) -> None:
         """--host flag is respected under the client_token auth mode."""
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
@@ -113,28 +108,17 @@ class TestMain:
 
             main()
 
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="0.0.0.0",  # noqa: S104
-                port=8000,
-                uvicorn_config={"ws": "wsproto"},
-                host_origin_protection="auto",
-                allowed_hosts=None,
-                allowed_origins=None,
-            )
-        get_settings.cache_clear()
+            mock_mcp.run.assert_called_once_with(host="0.0.0.0", **HTTP_RUN_KWARGS)  # noqa: S104
 
 
 class TestHttpTransportSecurity:
     """main() guard for unauthenticated HTTP: warn (never refuse), louder off-loopback."""
 
-    def test_http_static_token_public_runs_with_warning(self, monkeypatch) -> None:
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
+    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1"])  # noqa: S104
+    def test_http_static_token_runs_with_warning(self, monkeypatch, host: str) -> None:
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
-        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", host])
 
         with (
             patch("mcp_server_mattermost.server.mcp") as mock_mcp,
@@ -146,72 +130,49 @@ class TestHttpTransportSecurity:
 
             main()
 
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="0.0.0.0",  # noqa: S104
-                port=8000,
-                uvicorn_config={"ws": "wsproto"},
-                host_origin_protection="auto",
-                allowed_hosts=None,
-                allowed_origins=None,
-            )
+            mock_mcp.run.assert_called_once_with(host=host, **HTTP_RUN_KWARGS)
             mock_logger.warning.assert_called_once()
-        get_settings.cache_clear()
 
-    def test_http_static_token_loopback_runs_with_warning(self, monkeypatch) -> None:
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
-        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
-        monkeypatch.setenv("MATTERMOST_TOKEN", "test-token")
-        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "127.0.0.1"])
-
-        with (
-            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
-            patch("mcp_server_mattermost.logging.logger") as mock_logger,
-            patch("mcp_server_mattermost.logging.setup_logging"),
-        ):
-            mock_mcp.run = MagicMock()
-            from mcp_server_mattermost import main
-
-            main()
-
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="127.0.0.1",
-                port=8000,
-                uvicorn_config={"ws": "wsproto"},
-                host_origin_protection="auto",
-                allowed_hosts=None,
-                allowed_origins=None,
-            )
-            mock_logger.warning.assert_called_once()
-        get_settings.cache_clear()
-
-    def test_http_client_token_runs_without_optin(self, monkeypatch) -> None:
-        from mcp_server_mattermost.config import get_settings
-
-        get_settings.cache_clear()
+    def test_http_client_token_runs_without_warning(self, monkeypatch) -> None:
         monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
         monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http", "--host", "0.0.0.0"])  # noqa: S104
 
-        with patch("mcp_server_mattermost.server.mcp") as mock_mcp:
+        with (
+            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
+            patch("mcp_server_mattermost.logging.logger") as mock_logger,
+            patch("mcp_server_mattermost.logging.setup_logging"),
+        ):
             mock_mcp.run = MagicMock()
             from mcp_server_mattermost import main
 
             main()
 
-            mock_mcp.run.assert_called_once_with(
-                transport="http",
-                host="0.0.0.0",  # noqa: S104
-                port=8000,
-                uvicorn_config={"ws": "wsproto"},
-                host_origin_protection="auto",
-                allowed_hosts=None,
-                allowed_origins=None,
-            )
-        get_settings.cache_clear()
+            mock_mcp.run.assert_called_once_with(host="0.0.0.0", **HTTP_RUN_KWARGS)  # noqa: S104
+            mock_logger.warning.assert_not_called()
+
+    def test_inert_allowlist_warns(self, monkeypatch) -> None:
+        """An allowlist without protection enabled is dead configuration; say so."""
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
+        monkeypatch.setenv("MATTERMOST_HTTP_ALLOWED_HOSTS", "good.example")
+        monkeypatch.setattr(sys, "argv", ["mcp-server-mattermost", "--http"])
+
+        with (
+            patch("mcp_server_mattermost.server.mcp") as mock_mcp,
+            patch("mcp_server_mattermost.logging.logger") as mock_logger,
+            patch("mcp_server_mattermost.logging.setup_logging"),
+            patch("mcp_server_mattermost.http_security.effective_protection") as mock_effective,
+        ):
+            from mcp_server_mattermost.config import HostOriginProtection
+
+            mock_effective.return_value = HostOriginProtection.OFF
+            mock_mcp.run = MagicMock()
+            from mcp_server_mattermost import main
+
+            main()
+
+            assert "no effect" in mock_logger.warning.call_args[0][0]
 
 
 class TestVersion:

--- a/tests/test_main_env.py
+++ b/tests/test_main_env.py
@@ -22,6 +22,7 @@ class TestMainEnvVars:
     def test_mcp_transport_http_env_var(self, mock_settings, mock_mcp_run, monkeypatch):
         """MCP_TRANSPORT=http triggers HTTP mode."""
         monkeypatch.setenv("MCP_TRANSPORT", "http")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr("sys.argv", ["mcp-server-mattermost"])
 
         from mcp_server_mattermost import main
@@ -36,6 +37,7 @@ class TestMainEnvVars:
         """MCP_HOST env var sets HTTP host."""
         monkeypatch.setenv("MCP_TRANSPORT", "http")
         monkeypatch.setenv("MCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr("sys.argv", ["mcp-server-mattermost"])
 
         from mcp_server_mattermost import main
@@ -49,6 +51,7 @@ class TestMainEnvVars:
         """MCP_PORT env var sets HTTP port."""
         monkeypatch.setenv("MCP_TRANSPORT", "http")
         monkeypatch.setenv("MCP_PORT", "9000")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr("sys.argv", ["mcp-server-mattermost"])
 
         from mcp_server_mattermost import main
@@ -61,6 +64,7 @@ class TestMainEnvVars:
     def test_cli_args_override_env_vars(self, mock_settings, mock_mcp_run, monkeypatch):
         """CLI arguments take precedence over env vars."""
         monkeypatch.setenv("MCP_PORT", "9000")
+        monkeypatch.setenv("MATTERMOST_AUTH_MODE", "client_token")
         monkeypatch.setattr("sys.argv", ["mcp-server-mattermost", "--http", "--port", "8080"])
 
         from mcp_server_mattermost import main

--- a/uv.lock
+++ b/uv.lock
@@ -1253,7 +1253,7 @@ requires-dist = [
     { name = "asgi-lifespan", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "cachetools", specifier = ">=5.0" },
     { name = "certifi" },
-    { name = "fastmcp", specifier = ">=3.4,<4" },
+    { name = "fastmcp", specifier = ">=3.4.4,<4" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },

--- a/uv.lock
+++ b/uv.lock
@@ -1258,7 +1258,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "wsproto", specifier = ">=1.3.2" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1230,6 +1230,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+docs = [
+    { name = "mkdocs-material" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
     { name = "mypy" },
@@ -1244,35 +1249,36 @@ dev = [
     { name = "testcontainers" },
     { name = "types-cachetools" },
 ]
-docs = [
-    { name = "mkdocs-material" },
-]
 
 [package.metadata]
 requires-dist = [
-    { name = "asgi-lifespan", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "cachetools", specifier = ">=5.0" },
     { name = "certifi" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "pymarkdownlnt", marker = "extra == 'dev'", specifier = ">=0.9.35" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12" },
-    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "tenacity", specifier = ">=9.0.0" },
-    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "types-cachetools", marker = "extra == 'dev'" },
     { name = "wsproto", specifier = ">=1.3.2" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["docs"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pre-commit", specifier = ">=4.0" },
+    { name = "pymarkdownlnt", specifier = ">=0.9.35" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-mock", specifier = ">=3.12" },
+    { name = "respx", specifier = ">=0.22" },
+    { name = "ruff", specifier = ">=0.8" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0" },
+    { name = "types-cachetools" },
+]
 
 [[package]]
 name = "mdurl"


### PR DESCRIPTION
## Summary

Adds **opt-in** DNS-rebinding (Host/Origin) protection to the HTTP transport, plus a startup security
warning for `static_token` served over HTTP. No existing deployment changes behavior on upgrade.

## What changed

- **Warning, not a refusal, for `static_token` over HTTP.** In `static_token` mode the shared Mattermost
  token is used server-side for every tool call, so an HTTP endpoint in this mode is unauthenticated with
  full token privileges. The server logs a warning at startup — plain on a loopback bind, louder on a
  non-loopback bind — and always starts. This matches the MCP specification's posture, where client
  authentication is a SHOULD and the hard control is Host/Origin validation. stdio is unchanged.

- **Opt-in DNS-rebinding protection** via `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` (`off` / `auto` /
  `strict`). Leaving it unset touches nothing, so FastMCP's own default (off) and an operator's
  `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` both survive. Under `auto` each connection is validated by the
  local address it arrives on. `MATTERMOST_HTTP_ALLOWED_HOSTS` / `MATTERMOST_HTTP_ALLOWED_ORIGINS`
  declare allowlists; the server warns when they are set while protection is off.

- **The posture applies on every entry point.** It is written into FastMCP's settings at server-module
  import rather than passed as `mcp.run()` kwargs, so it also covers `fastmcp run`, a standalone ASGI
  server over `mcp.http_app()`, and the app mounted into a parent Starlette/FastAPI application.
  Passing kwargs would have protected only the console entry point — and would have silently overridden
  `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` in both directions.

- **Rejections are logged** at `WARNING` with the offending `Host`/`Origin`, the address the connection
  arrived on, and the variable that would accept it. The logger is installed ahead of FastMCP's guard,
  since anything passed through `http_app(middleware=...)` runs inside it and cannot observe the
  `421`/`403`. The response body is unchanged — diagnostics go to the server log only.

- **Allowlist parsing.** Bracketed IPv6 literals (`[::1]`, `[::1],127.0.0.1`) are accepted; they
  previously aborted startup with a JSON parser error, and `[::1]` is the canonical IPv6 `Host` spelling.
  A value reducing to an empty list (`[]`, a stray trailing comma) is treated as unset, because FastMCP
  reads any non-`None` allowlist as explicit — so `[]` used to turn validation on everywhere.

- **Dependency floors.** `fastmcp>=3.4.4,<4` (3.4.3 is the first release with the Host/Origin protection
  this transport relies on; 3.4.4 is the tested and locked version, and fixes CVE-2026-27124,
  CVE-2026-32871 and CVE-2025-64340). `pydantic-settings>=2.7`, because `config.py` imports `NoDecode`,
  which first exists in 2.7.0 — the previous `>=2.0` floor permitted versions where the package could not
  be imported at all, on stdio as well as HTTP.

- **Packaging.** The `dev` extra moved from `[project.optional-dependencies]` to `[dependency-groups]`.

## Backward compatibility

Nothing breaks. With the new variable unset the transport behaves exactly as in 0.5.1: no `Host`/`Origin`
request is rejected, and `static_token` over HTTP starts on any bind. The `MATTERMOST_ALLOW_UNAUTHENTICATED_HTTP`
opt-in from an earlier revision of this branch was dropped along with the fail-closed behavior.

The default becomes `auto` in 1.0.0 — recorded under `### Deprecated` in `CHANGELOG.md`, announced in the
startup log, and tracked in #30. Operators who set the variable explicitly now, including `=off`, see no
change across that upgrade.

## Testing

- `ruff check` / `ruff format --check` / `mypy src` — clean
- `pytest` — 711 passed
- Behavioral coverage drives a real Starlette `TestClient` through FastMCP's actual guard: the
  arrival-address matrix (loopback vs LAN, each allowlist combination), `200` for the missing-`Origin`
  case that every non-browser MCP client hits, rejection logging, and secret-non-leakage assertions.
  `tests/test_http_guard_log.py` asserts that `mcp.http_app()` with no keyword arguments inherits the
  configured posture, which is the path `fastmcp run` and an ASGI server take.
- Verified against a running server: default config answers `200` to a reverse-proxy `Host`;
  `=auto` answers `421` and logs the rejected host; adding it to `MATTERMOST_HTTP_ALLOWED_HOSTS` restores
  `200`; `uvicorn --factory ...:mcp.http_app` enforces the posture too.

## New configuration

| Env var | Default | Purpose |
|---|---|---|
| `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` | none | Host/Origin protection: `off`, `auto`, or `strict` (unset defers to FastMCP, which is off) |
| `MATTERMOST_HTTP_ALLOWED_HOSTS` | none | Extra allowed `Host` values (JSON array or comma-separated) |
| `MATTERMOST_HTTP_ALLOWED_ORIGINS` | none | Extra allowed `Origin` values (JSON array or comma-separated) |
