### PR TITLE
perf: shared HTTP connection pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,9 @@ Optional:
 - `MATTERMOST_LOG_LEVEL` (default: INFO)
 - `MATTERMOST_LOG_FORMAT` (default: json) - Log format: 'json' for production, 'text' for development
 - `MATTERMOST_API_VERSION` (default: v4)
+- `MATTERMOST_MAX_CONNECTIONS` (default: 100) - Max HTTP connections in the shared pool
+- `MATTERMOST_MAX_KEEPALIVE_CONNECTIONS` (default: 20) - Max idle keepalive connections (≤ max connections)
+- `MATTERMOST_KEEPALIVE_EXPIRY` (default: 5.0) - Idle keepalive connection lifetime in seconds
 - `MATTERMOST_ALLOW_HTTP_CLIENT_TOKENS` (default: false) - Allow HTTP clients to use their own Mattermost tokens
 - `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` (default: none) - Host/Origin protection: `off`, `auto`, or `strict`
 - `MATTERMOST_HTTP_ALLOWED_HOSTS` (default: none) - Extra allowed `Host` header values (JSON array or comma-separated)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Post.file_ids` defaults to an empty list — Mattermost ≤ v10.4.0 omits the key on posts
   without attachments, which broke parsing in every tool that returns posts
   ([#27](https://github.com/cloud-ru-tech/mcp-server-mattermost/issues/27))
+- Allowlists accept bracketed IPv6 literals (`[::1]`), which previously aborted startup with a JSON
+  parser error; a value reducing to an empty list is now treated as unset rather than as an allowlist
+  matching nothing.
+- Raised the `pydantic-settings` floor to `>=2.7`. The declared `>=2.0` allowed versions without
+  `NoDecode`, where the package failed to import at all — on stdio as well as HTTP.
 
 ### Security
 - The shared HTTP pool is transport-only: its cookie jar is disabled, so a
@@ -57,13 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Host/Origin protection defaults to off; **in 1.0.0 the default becomes `auto`** (#30). Set
   `MATTERMOST_HTTP_HOST_ORIGIN_PROTECTION` explicitly now — `=off` included — and that upgrade changes
   nothing for you.
-
-### Fixed
-- Allowlists accept bracketed IPv6 literals (`[::1]`), which previously aborted startup with a JSON
-  parser error; a value reducing to an empty list is now treated as unset rather than as an allowlist
-  matching nothing.
-- Raised the `pydantic-settings` floor to `>=2.7`. The declared `>=2.0` allowed versions without
-  `NoDecode`, where the package failed to import at all — on stdio as well as HTTP.
 
 ## [0.5.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File uploads now send the correct `multipart/form-data` Content-Type. The
   client previously carried a default `Content-Type: application/json` header
   that httpx did not override for multipart requests.
+- Server shutdown now closes the auth provider even if closing the shared HTTP
+  pool fails, so a failing `aclose()` no longer leaks the auth provider.
 - `Post.file_ids` defaults to an empty list — Mattermost ≤ v10.4.0 omits the key on posts
   without attachments, which broke parsing in every tool that returns posts
   ([#27](https://github.com/cloud-ru-tech/mcp-server-mattermost/issues/27))
 
 ### Security
+- The shared HTTP pool is transport-only: its cookie jar is disabled, so a
+  `Set-Cookie` from one user's response is never stored and replayed on another
+  user's request through the pool (`client_token`/`oauth_proxy` modes).
 - Upgraded FastMCP to 3.4.4 — fixes CVE-2026-27124 (GHSA-rww4-4w9c-7733, missing consent check in the
   OAuth proxy callback), plus CVE-2026-32871 (authenticated SSRF) and CVE-2025-64340 (command injection)
   present in the previous 3.0.2. Floor raised to `fastmcp>=3.4.4,<4`; 3.4.3 is the first release with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Shared HTTP connection pool: the Mattermost HTTP client is created once at
+  startup and reused across all tool calls (sequential and concurrent),
+  eliminating per-call TCP/TLS handshakes and TIME_WAIT churn. Pool limits are
+  configurable via `MATTERMOST_MAX_CONNECTIONS` (default 100),
+  `MATTERMOST_MAX_KEEPALIVE_CONNECTIONS` (default 20), and
+  `MATTERMOST_KEEPALIVE_EXPIRY` (default 5.0s). The bearer token is sent
+  per-request and is never stored in the shared client's default headers, so a
+  single pool safely serves multiple users without mixing tokens.
+
 ### Fixed
+- File uploads now send the correct `multipart/form-data` Content-Type. The
+  client previously carried a default `Content-Type: application/json` header
+  that httpx did not override for multipart requests.
 - `Post.file_ids` defaults to an empty list — Mattermost ≤ v10.4.0 omits the key on posts
   without attachments, which broke parsing in every tool that returns posts
   ([#27](https://github.com/cloud-ru-tech/mcp-server-mattermost/issues/27))

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Once configured, you can ask your AI assistant:
 | `MATTERMOST_TIMEOUT` | No | 30 | Request timeout in seconds |
 | `MATTERMOST_MAX_RETRIES` | No | 3 | Max retry attempts |
 | `MATTERMOST_VERIFY_SSL` | No | true | Verify SSL certificates |
+| `MATTERMOST_MAX_CONNECTIONS` | No | 100 | Max HTTP connections in the shared pool |
+| `MATTERMOST_MAX_KEEPALIVE_CONNECTIONS` | No | 20 | Max idle keepalive connections |
+| `MATTERMOST_KEEPALIVE_EXPIRY` | No | 5.0 | Idle keepalive connection lifetime in seconds |
 | `MATTERMOST_EXTRA_CA_CERTS` | No | — | Path to extra PEM CAs appended to the default trust store |
 | `MATTERMOST_LOG_LEVEL` | No | INFO | Logging level |
 | `MATTERMOST_LOG_FORMAT` | No | json | Log output format: `json` or `text` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,9 @@ all `MATTERMOST_OAUTH_*`), see [Authentication](authentication.md).
 | `MATTERMOST_TIMEOUT` | 30 | Request timeout in seconds (1-300) |
 | `MATTERMOST_MAX_RETRIES` | 3 | Maximum retry attempts for failed requests (0-10) |
 | `MATTERMOST_VERIFY_SSL` | true | Verify SSL certificates |
+| `MATTERMOST_MAX_CONNECTIONS` | 100 | Max HTTP connections in the shared pool (1-1000) |
+| `MATTERMOST_MAX_KEEPALIVE_CONNECTIONS` | 20 | Max idle keepalive connections; must be ≤ max connections (0-1000) |
+| `MATTERMOST_KEEPALIVE_EXPIRY` | 5.0 | Seconds an idle keepalive connection stays in the pool (0-600) |
 | `MATTERMOST_EXTRA_CA_CERTS` | — | Path to extra PEM CAs appended to the default trust store |
 | `MATTERMOST_LOG_LEVEL` | INFO | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `MATTERMOST_LOG_FORMAT` | json | Log format: `json` for production, `text` for development |

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -72,6 +72,36 @@ def _wait_for_rate_limit(retry_state: RetryCallState) -> float:
     return float(wait_exponential(multiplier=1, min=1, max=10)(retry_state))
 
 
+def create_http_client(settings: Settings) -> httpx.AsyncClient:
+    """Create an httpx.AsyncClient configured for the Mattermost API.
+
+    The client carries no ``Authorization`` or ``Content-Type`` default header.
+    ``Authorization`` is attached per-request (so one shared pool can serve
+    multiple users without mixing tokens), and httpx derives ``Content-Type``
+    per-request from the ``json=``/``files=`` body (correct multipart uploads).
+
+    Security note: httpx does not log request headers by default. If enabling
+    httpx debug logging (HTTPX_LOG_LEVEL=debug), ensure bearer tokens are not
+    exposed.
+
+    Args:
+        settings: Application configuration.
+
+    Returns:
+        Configured httpx.AsyncClient. The caller owns its lifecycle.
+    """
+    return httpx.AsyncClient(
+        base_url=f"{settings.url}/api/{settings.api_version}",
+        timeout=httpx.Timeout(settings.timeout),
+        verify=settings.verify_ssl,
+        limits=httpx.Limits(
+            max_connections=settings.max_connections,
+            max_keepalive_connections=settings.max_keepalive_connections,
+            keepalive_expiry=settings.keepalive_expiry,
+        ),
+    )
+
+
 class MattermostClient:
     """Async client for Mattermost REST API v4.
 

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -1,6 +1,7 @@
 """Async HTTP client for Mattermost API v4."""
 
 import asyncio
+import http.cookiejar
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -99,6 +100,11 @@ def create_http_client(settings: Settings) -> httpx.AsyncClient:
             max_keepalive_connections=settings.max_keepalive_connections,
             keepalive_expiry=settings.keepalive_expiry,
         ),
+        # The shared pool serves multiple tenants (client_token/oauth_proxy modes),
+        # so keep it transport-only: a jar that accepts no domain never stores a
+        # Set-Cookie from one user's response nor replays it on another's request.
+        # Authentication always travels in the per-request Authorization header.
+        cookies=http.cookiejar.CookieJar(policy=http.cookiejar.DefaultCookiePolicy(allowed_domains=[])),
     )
 
 
@@ -151,23 +157,21 @@ class MattermostClient:
             logger.warning("Initializing Mattermost API client without authentication token")
 
         if self._borrowed_client is not None:
-            self._client = self._borrowed_client
-            self._current_user_id = None
-            try:
-                yield self
-            finally:
-                self._client = None
-                self._current_user_id = None
+            client = self._borrowed_client
+            owns_client = False
         else:
             client = create_http_client(self.settings)
-            self._client = client
+            owns_client = True
+
+        self._client = client
+        self._current_user_id = None
+        try:
+            yield self
+        finally:
+            self._client = None
             self._current_user_id = None
-            try:
-                yield self
-            finally:
+            if owns_client:
                 await client.aclose()
-                self._client = None
-                self._current_user_id = None
                 logger.info("Mattermost API client closed")
 
     def _make_retrying(self) -> Callable[[_F], _F]:

--- a/src/mcp_server_mattermost/client.py
+++ b/src/mcp_server_mattermost/client.py
@@ -110,50 +110,65 @@ class MattermostClient:
             channels = await client.get_channels(team_id)
     """
 
-    def __init__(self, settings: Settings, token: str | None = None) -> None:
-        """Initialize client with settings and optional token override.
+    def __init__(
+        self,
+        settings: Settings,
+        token: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize client with settings, optional token override, and optional shared client.
 
         Args:
-            settings: Application configuration
-            token: Optional token override (e.g. from request); used instead of settings.token when set
+            settings: Application configuration.
+            token: Optional token override (e.g. from request); used instead of settings.token.
+            http_client: Optional shared httpx.AsyncClient to borrow. When provided, the client's
+                lifecycle is owned by the caller and ``lifespan()`` will not close it.
         """
         self.settings = settings
         self._token_override = token
+        self._borrowed_client = http_client
         self._client: httpx.AsyncClient | None = None
         self._current_user_id: str | None = None
+        raw = token if token is not None else (settings.token or "")
+        effective_token = raw.strip()
+        self._auth_headers: dict[str, str] = {"Authorization": f"Bearer {effective_token}"} if effective_token else {}
 
     @asynccontextmanager
     async def lifespan(self) -> AsyncIterator["MattermostClient"]:
         """Context manager for client lifecycle.
 
-        Security note: httpx does not log request headers by default.
-        If enabling httpx debug logging (HTTPX_LOG_LEVEL=debug), ensure
-        tokens are not exposed. The Authorization header contains a bearer
-        token that must remain secret.
+        Borrows the shared client when one was supplied (does not close it), or
+        creates and closes its own via ``create_http_client`` otherwise. The
+        bearer token is never placed in the client's default headers; it is
+        attached per-request (see ``_request``).
 
         Yields:
-            Self with initialized httpx client
+            Self with an active httpx client.
         """
-        raw = self._token_override if self._token_override is not None else (self.settings.token or "")
-        effective_token = raw.strip()
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        if effective_token:
-            headers["Authorization"] = f"Bearer {effective_token}"
+        if self._auth_headers:
             logger.info("Initializing Mattermost API client")
         else:
             logger.warning("Initializing Mattermost API client without authentication token")
-        async with httpx.AsyncClient(
-            base_url=f"{self.settings.url}/api/{self.settings.api_version}",
-            headers=headers,
-            timeout=httpx.Timeout(self.settings.timeout),
-            verify=self.settings.verify_ssl,
-        ) as client:
+
+        if self._borrowed_client is not None:
+            self._client = self._borrowed_client
+            self._current_user_id = None
+            try:
+                yield self
+            finally:
+                self._client = None
+                self._current_user_id = None
+        else:
+            client = create_http_client(self.settings)
             self._client = client
-            self._current_user_id = None  # Reset cache on new lifespan
-            yield self
-            self._client = None
-            self._current_user_id = None  # Clear cache on exit
-        logger.info("Mattermost API client closed")
+            self._current_user_id = None
+            try:
+                yield self
+            finally:
+                await client.aclose()
+                self._client = None
+                self._current_user_id = None
+                logger.info("Mattermost API client closed")
 
     def _make_retrying(self) -> Callable[[_F], _F]:
         """Create tenacity retry decorator with instance settings.
@@ -302,6 +317,9 @@ class MattermostClient:
     ) -> dict[str, Any] | list[Any] | None:
         """Make HTTP request to Mattermost API with retry.
 
+        The bearer token is injected per-request; explicit ``headers`` passed by
+        callers take precedence on key conflicts.
+
         Args:
             method: HTTP method (GET, POST, PUT, DELETE)
             endpoint: API endpoint (e.g., "/users/me")
@@ -318,11 +336,12 @@ class MattermostClient:
             MattermostAPIError: For other API errors
         """
         retrying = self._make_retrying()
+        headers = {**self._auth_headers, **(kwargs.pop("headers", None) or {})}
 
         @retrying
         async def _do_request() -> dict[str, Any] | list[Any] | None:
             self._log_http_request(method, endpoint)
-            response = await self._http.request(method, endpoint, **kwargs)
+            response = await self._http.request(method, endpoint, headers=headers, **kwargs)
             self._log_http_response(response.status_code)
             return self._handle_response(response)
 
@@ -1144,6 +1163,7 @@ class MattermostClient:
                 params={"channel_id": channel_id, "filename": filename},
                 data={"channel_id": channel_id},
                 files={"files": (filename, content)},
+                headers=self._auth_headers,
             )
             self._log_http_response(response.status_code)
             return self._handle_response(response)

--- a/src/mcp_server_mattermost/config.py
+++ b/src/mcp_server_mattermost/config.py
@@ -63,6 +63,9 @@ class Settings(BaseSettings):
         MATTERMOST_OAUTH_MATTERMOST_PUBLIC_URL: Browser-facing Mattermost URL
         MATTERMOST_TIMEOUT: Request timeout in seconds (default: 30)
         MATTERMOST_MAX_RETRIES: Max retry attempts (default: 3)
+        MATTERMOST_MAX_CONNECTIONS: Max HTTP connections in the shared pool (default: 100)
+        MATTERMOST_MAX_KEEPALIVE_CONNECTIONS: Max idle keepalive connections (default: 20)
+        MATTERMOST_KEEPALIVE_EXPIRY: Idle keepalive connection lifetime in seconds (default: 5.0)
         MATTERMOST_VERIFY_SSL: Verify SSL certificates (default: true)
         MATTERMOST_EXTRA_CA_CERTS: Path to PEM file with additional trusted CAs
         MATTERMOST_LOG_LEVEL: Logging level (default: INFO)
@@ -89,6 +92,13 @@ class Settings(BaseSettings):
     )
     timeout: int = Field(default=30, ge=1, le=300, description="Request timeout in seconds")
     max_retries: int = Field(default=3, ge=0, le=10, description="Maximum retry attempts")
+    max_connections: int = Field(default=100, ge=1, le=1000, description="Max HTTP connections in the shared pool")
+    max_keepalive_connections: int = Field(
+        default=20, ge=0, le=1000, description="Max idle keepalive connections in the shared pool"
+    )
+    keepalive_expiry: float = Field(
+        default=5.0, ge=0, le=600, description="Seconds an idle keepalive connection stays in the pool"
+    )
     verify_ssl: bool = Field(default=True, description="Verify SSL certificates")
     extra_ca_certs: str | None = Field(
         default=None,
@@ -245,6 +255,14 @@ class Settings(BaseSettings):
         if self.auth_mode is AuthMode.OAUTH_PROXY:
             self._validate_oauth_proxy()
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_pool_limits(self) -> "Settings":
+        """Keepalive connections cannot exceed the total connection cap."""
+        if self.max_keepalive_connections > self.max_connections:
+            msg = "MATTERMOST_MAX_KEEPALIVE_CONNECTIONS cannot exceed MATTERMOST_MAX_CONNECTIONS"
+            raise ValueError(msg)
         return self
 
     def _validate_oauth_proxy(self) -> None:

--- a/src/mcp_server_mattermost/constants.py
+++ b/src/mcp_server_mattermost/constants.py
@@ -25,3 +25,7 @@ FILE_UPLOADED = "File uploaded successfully"
 # API response wrapper keys (from Mattermost Go source)
 # See: https://github.com/mattermost/mattermost/blob/master/server/public/model/channel_bookmark.go
 UPDATE_BOOKMARK_RESPONSE_KEY = "updated"
+
+# Lifespan context keys
+# Key under which app_lifespan stores the shared httpx.AsyncClient; read by get_client.
+LIFESPAN_HTTP_CLIENT_KEY = "http_client"

--- a/src/mcp_server_mattermost/deps.py
+++ b/src/mcp_server_mattermost/deps.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.dependencies import get_access_token, get_context
 
 from .client import MattermostClient
 from .config import AuthMode, get_settings
@@ -26,10 +26,17 @@ def _get_mattermost_token_from_auth_context() -> str:
 
 @asynccontextmanager
 async def get_client() -> AsyncIterator[MattermostClient]:
-    """Provide Mattermost client with automatic lifecycle management.
+    """Provide a Mattermost client bound to the process-wide shared HTTP pool.
+
+    The shared ``httpx.AsyncClient`` is created once by ``app_lifespan`` and
+    reached here via the FastMCP request context. The per-request token is
+    attached by ``MattermostClient``; it is never stored in the shared client.
 
     Yields:
-        MattermostClient ready for API calls
+        MattermostClient ready for API calls.
+
+    Raises:
+        RuntimeError: If the shared HTTP client is not available (server lifespan not running).
     """
     settings = get_settings()
     token: str | None = None
@@ -37,6 +44,11 @@ async def get_client() -> AsyncIterator[MattermostClient]:
     if settings.auth_mode in {AuthMode.CLIENT_TOKEN, AuthMode.OAUTH_PROXY}:
         token = _get_mattermost_token_from_auth_context()
 
-    client = MattermostClient(settings, token=token)
+    http_client = get_context().lifespan_context.get("http_client")
+    if http_client is None:
+        msg = "Shared HTTP client is not initialized — app_lifespan is not running"
+        raise RuntimeError(msg)
+
+    client = MattermostClient(settings, token=token, http_client=http_client)
     async with client.lifespan():
         yield client

--- a/src/mcp_server_mattermost/deps.py
+++ b/src/mcp_server_mattermost/deps.py
@@ -7,6 +7,7 @@ from fastmcp.server.dependencies import get_access_token, get_context
 
 from .client import MattermostClient
 from .config import AuthMode, get_settings
+from .constants import LIFESPAN_HTTP_CLIENT_KEY
 from .exceptions import AuthenticationError
 
 
@@ -44,7 +45,7 @@ async def get_client() -> AsyncIterator[MattermostClient]:
     if settings.auth_mode in {AuthMode.CLIENT_TOKEN, AuthMode.OAUTH_PROXY}:
         token = _get_mattermost_token_from_auth_context()
 
-    http_client = get_context().lifespan_context.get("http_client")
+    http_client = get_context().lifespan_context.get(LIFESPAN_HTTP_CLIENT_KEY)
     if http_client is None:
         msg = "Shared HTTP client is not initialized — app_lifespan is not running"
         raise RuntimeError(msg)

--- a/src/mcp_server_mattermost/server.py
+++ b/src/mcp_server_mattermost/server.py
@@ -14,6 +14,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .auth_factory import build_auth_provider_from_env
+from .client import create_http_client
 from .config import get_settings
 from .http_guard_log import GuardRejectionLoggingMiddleware
 from .http_security import apply_http_security_settings
@@ -24,21 +25,23 @@ from .tls import install_extra_ca_certs
 
 @lifespan
 async def app_lifespan(_server: FastMCP) -> AsyncIterator[dict[str, object]]:
-    """Manage application lifecycle.
+    """Manage application lifecycle and own the shared HTTP connection pool.
 
     Args:
-        _server: FastMCP server instance (required by FastMCP lifespan protocol)
+        _server: FastMCP server instance (required by FastMCP lifespan protocol).
 
     Yields:
-        Empty dict (no shared lifespan state needed)
+        Lifespan context with the shared httpx.AsyncClient under "http_client".
     """
     settings = get_settings()
     setup_logging(settings.log_level, settings.log_format)
     logger.info("Starting Mattermost MCP server")
     logger.debug("Server URL: %s", settings.url)
+    http_client = create_http_client(settings)
     try:
-        yield {}
+        yield {"http_client": http_client}
     finally:
+        await http_client.aclose()
         if _server.auth is not None and hasattr(_server.auth, "close"):
             await _server.auth.close()
         logger.info("Mattermost MCP server shutdown complete")

--- a/src/mcp_server_mattermost/server.py
+++ b/src/mcp_server_mattermost/server.py
@@ -16,6 +16,7 @@ from starlette.responses import JSONResponse
 from .auth_factory import build_auth_provider_from_env
 from .client import create_http_client
 from .config import get_settings
+from .constants import LIFESPAN_HTTP_CLIENT_KEY
 from .http_guard_log import GuardRejectionLoggingMiddleware
 from .http_security import apply_http_security_settings
 from .logging import logger, setup_logging
@@ -31,7 +32,7 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[dict[str, object]]:
         _server: FastMCP server instance (required by FastMCP lifespan protocol).
 
     Yields:
-        Lifespan context with the shared httpx.AsyncClient under "http_client".
+        Lifespan context with the shared httpx.AsyncClient under LIFESPAN_HTTP_CLIENT_KEY.
     """
     settings = get_settings()
     setup_logging(settings.log_level, settings.log_format)
@@ -39,12 +40,14 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[dict[str, object]]:
     logger.debug("Server URL: %s", settings.url)
     http_client = create_http_client(settings)
     try:
-        yield {"http_client": http_client}
+        yield {LIFESPAN_HTTP_CLIENT_KEY: http_client}
     finally:
-        await http_client.aclose()
-        if _server.auth is not None and hasattr(_server.auth, "close"):
-            await _server.auth.close()
-        logger.info("Mattermost MCP server shutdown complete")
+        try:
+            await http_client.aclose()
+        finally:
+            if _server.auth is not None and hasattr(_server.auth, "close"):
+                await _server.auth.close()
+            logger.info("Mattermost MCP server shutdown complete")
 
 
 class MattermostMCP(FastMCP):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,10 +12,13 @@ Fixtures provide:
 """
 
 import contextlib
+import inspect
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
+import pytest_asyncio
 from _pytest.monkeypatch import MonkeyPatch
 from fastmcp import Client
 
@@ -29,19 +32,13 @@ from .utils import cleanup_channel, make_test_name, setup_docker_host, to_dict
 _DOCKER_AVAILABLE = setup_docker_host()
 
 
-@pytest.fixture(scope="session")
-def event_loop():
-    """Session-scoped event loop for async fixtures.
-
-    Replaces deprecated asyncio.get_event_loop() calls.
-    Required for session-scoped async operations with pytest-asyncio.
-    """
-    import asyncio
-
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Run async integration tests on the server's session-scoped event loop."""
+    integration_dir = Path(__file__).parent
+    session_loop = pytest.mark.asyncio(loop_scope="session")
+    for item in items:
+        if item.path.is_relative_to(integration_dir) and inspect.iscoroutinefunction(item.obj):
+            item.add_marker(session_loop, append=False)
 
 
 @dataclass
@@ -62,8 +59,8 @@ def monkeypatch_session():
     mp.undo()
 
 
-@pytest.fixture(scope="session")
-def mattermost_env(monkeypatch_session, event_loop) -> TestEnvironment:
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def mattermost_env(monkeypatch_session) -> TestEnvironment:
     """Configure test environment: external server or Testcontainers.
 
     If MATTERMOST_URL and MATTERMOST_TOKEN are set, uses external server.
@@ -78,13 +75,13 @@ def mattermost_env(monkeypatch_session, event_loop) -> TestEnvironment:
         # Remove trailing slash to avoid double-slash in URLs
         url = url.rstrip("/")
 
-        with httpx.Client(
+        async with httpx.AsyncClient(
             base_url=f"{url}/api/v4",
             headers={"Authorization": f"Bearer {token}"},
             timeout=30.0,
             follow_redirects=True,
         ) as client:
-            teams = client.get("/users/me/teams").json()
+            teams = (await client.get("/users/me/teams")).json()
             team_id = teams[0]["id"] if teams else ""
 
         yield TestEnvironment(url=url, token=token, team_id=team_id)
@@ -119,7 +116,7 @@ def mattermost_env(monkeypatch_session, event_loop) -> TestEnvironment:
             mm.start()
 
             try:
-                env_data = event_loop.run_until_complete(initialize_mattermost(mm.get_base_url()))
+                env_data = await initialize_mattermost(mm.get_base_url())
 
                 monkeypatch_session.setenv("MATTERMOST_URL", env_data["url"])
                 monkeypatch_session.setenv("MATTERMOST_TOKEN", env_data["token"])
@@ -138,7 +135,7 @@ def mattermost_env(monkeypatch_session, event_loop) -> TestEnvironment:
             postgres.stop()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture(loop_scope="session")
 async def mcp_client(mattermost_env):
     """MCP client connected to server via in-memory transport.
 
@@ -155,70 +152,33 @@ async def mcp_client(mattermost_env):
         yield client
 
 
-@pytest.fixture(scope="session")
-def session_mcp_client_sync(mattermost_env, event_loop):
-    """Session-scoped MCP client for setup operations (sync wrapper).
-
-    Uses a more robust pattern that properly handles exceptions during cleanup.
-    """
-    import warnings
-
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def session_mcp_client(mattermost_env):
+    """Session-scoped MCP client for setup and cleanup operations."""
     from mcp_server_mattermost.server import mcp
 
-    client = None
-    cleanup_exc = None
-
-    async def create_and_track():
-        nonlocal client
-        client = Client(mcp)
-        await client.__aenter__()
-        return client
-
-    try:
-        event_loop.run_until_complete(create_and_track())
+    async with Client(mcp) as client:
         yield client
-    finally:
-        if client is not None:
-
-            async def cleanup():
-                nonlocal cleanup_exc
-                try:
-                    await client.__aexit__(None, None, None)
-                except Exception as e:  # noqa: BLE001 - need to catch all to warn and continue
-                    cleanup_exc = e
-
-            event_loop.run_until_complete(cleanup())
-
-            if cleanup_exc is not None:
-                warnings.warn(f"Error during MCP client cleanup: {cleanup_exc}", stacklevel=2)
 
 
-@pytest.fixture(scope="session")
-def bot_user(session_mcp_client_sync, mattermost_env, event_loop):
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def bot_user(session_mcp_client, mattermost_env):
     """Bot user info (reused across all tests)."""
-
-    async def get_bot():
-        result = await session_mcp_client_sync.call_tool("get_me", {})
-        return to_dict(result)
-
-    return event_loop.run_until_complete(get_bot())
+    result = await session_mcp_client.call_tool("get_me", {})
+    return to_dict(result)
 
 
-@pytest.fixture(scope="session")
-def team(session_mcp_client_sync, mattermost_env, event_loop):
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def team(session_mcp_client, mattermost_env):
     """Test team info (reused across all tests)."""
-
-    async def get_team():
-        result = await session_mcp_client_sync.call_tool(
-            "get_team",
-            {"team_id": mattermost_env.team_id},
-        )
-        return to_dict(result)
-
-    return event_loop.run_until_complete(get_team())
+    result = await session_mcp_client.call_tool(
+        "get_team",
+        {"team_id": mattermost_env.team_id},
+    )
+    return to_dict(result)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture(loop_scope="session")
 async def test_channel(mcp_client, team):
     """Fresh channel for each test with cleanup."""
     name = make_test_name()
@@ -238,7 +198,7 @@ async def test_channel(mcp_client, team):
     await cleanup_channel(channel["id"])
 
 
-@pytest.fixture
+@pytest_asyncio.fixture(loop_scope="session")
 async def test_post(mcp_client, test_channel):
     """Fresh message for each test with cleanup."""
     result = await mcp_client.call_tool(
@@ -256,12 +216,12 @@ async def test_post(mcp_client, test_channel):
         await mcp_client.call_tool("delete_message", {"post_id": post["id"]})
 
 
-@pytest.fixture(scope="session", autouse=True)
-def cleanup_orphaned_resources(session_mcp_client_sync, mattermost_env, event_loop):
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
+async def cleanup_orphaned_resources(session_mcp_client, mattermost_env):
     """Clean up leftover test resources before and after tests."""
 
     async def cleanup():
-        result = await session_mcp_client_sync.call_tool(
+        result = await session_mcp_client.call_tool(
             "list_public_channels",
             {"team_id": mattermost_env.team_id},
         )
@@ -280,8 +240,8 @@ def cleanup_orphaned_resources(session_mcp_client_sync, mattermost_env, event_lo
                     with contextlib.suppress(Exception):
                         await client.delete(f"/channels/{channel['id']}")
 
-    event_loop.run_until_complete(cleanup())
+    await cleanup()
 
     yield
 
-    event_loop.run_until_complete(cleanup())
+    await cleanup()

--- a/tests/integration/test_token_flow.py
+++ b/tests/integration/test_token_flow.py
@@ -7,15 +7,19 @@ module-level ``mcp`` singleton used by other integration tests.
 Does NOT touch ``get_settings`` cache or environment variables — the
 standalone server's ``MattermostTokenVerifier`` picks up URL and SSL
 settings from the already-cached ``get_settings()`` (populated by the
-session ``mattermost_env`` fixture).
+session ``mattermost_env`` fixture). The tool dependency receives an
+isolated client-token settings copy so the test cannot fall back to the
+session's static token.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.client.auth import BearerAuth
 
+from mcp_server_mattermost.config import AuthMode, get_settings
 from tests.helpers import UvicornTestServer
 
 
@@ -26,9 +30,10 @@ def _create_token_flow_server() -> FastMCP:
     modules that would break the module-level ``mcp`` singleton's DI.
     """
     from mcp_server_mattermost.auth import MattermostTokenVerifier
+    from mcp_server_mattermost.server import app_lifespan
     from mcp_server_mattermost.tools.users import get_me
 
-    server = FastMCP(name="TokenFlowTest", auth=MattermostTokenVerifier())
+    server = FastMCP(name="TokenFlowTest", auth=MattermostTokenVerifier(), lifespan=app_lifespan)
     server.add_tool(get_me)
     return server
 
@@ -49,20 +54,27 @@ class TestClientTokenFlowIntegration:
             → get_me tool → GET /api/v4/users/me [REAL Mattermost]
             → User response
         """
-        mcp_server = _create_token_flow_server()
-        asgi_app = mcp_server.http_app(transport="streamable-http")
+        client_token_settings = get_settings().model_copy(
+            update={"auth_mode": AuthMode.CLIENT_TOKEN, "token": "unused-static-token"},
+        )
 
-        server = UvicornTestServer(asgi_app)
-        server.start()
-        assert server.wait_until_ready(), "MCP HTTP server did not start in time"
+        with patch("mcp_server_mattermost.deps.get_settings", return_value=client_token_settings):
+            mcp_server = _create_token_flow_server()
+            asgi_app = mcp_server.http_app(transport="streamable-http")
 
-        try:
-            mcp_url = f"{server.url}/mcp"
-            async with Client(mcp_url, auth=BearerAuth(mattermost_env.token)) as client:
-                result = await client.call_tool("get_me", {})
-        finally:
-            server.stop()
-            server.join(timeout=5.0)
+            server = UvicornTestServer(asgi_app)
+            server.start()
+            assert server.wait_until_ready(), "MCP HTTP server did not start in time"
+
+            try:
+                mcp_url = f"{server.url}/mcp"
+                async with Client(mcp_url, auth=BearerAuth(mattermost_env.token)) as client:
+                    result = await client.call_tool("get_me", {})
+            finally:
+                server.stop()
+                server.join(timeout=5.0)
+
+            assert not server.is_alive(), "MCP HTTP server did not stop in time"
 
         assert result is not None
         data = json.loads(result.content[0].text)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2358,3 +2358,50 @@ class TestTokenOverride:
 
         # Check the Authorization header was set with the override token
         assert route.calls[0].request.headers["authorization"] == "Bearer my-override-token"
+
+
+class TestCreateHttpClient:
+    @pytest.mark.asyncio
+    async def test_factory_base_url_and_clean_headers(self, mock_settings):
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        client = create_http_client(get_settings())
+        try:
+            assert str(client.base_url).rstrip("/") == "https://test.mattermost.com/api/v4"
+            assert "authorization" not in client.headers
+            assert "content-type" not in client.headers
+        finally:
+            await client.aclose()
+        assert client.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_factory_passes_limits_from_settings(self, mock_settings, mocker):
+        import httpx
+
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        spy = mocker.spy(httpx, "AsyncClient")
+        client = create_http_client(get_settings())
+        try:
+            limits = spy.call_args.kwargs["limits"]
+            assert limits.max_connections == 100
+            assert limits.max_keepalive_connections == 20
+            assert limits.keepalive_expiry == 5.0
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_factory_client_infers_multipart_content_type(self, mock_settings):
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        client = create_http_client(get_settings())
+        try:
+            req = client.build_request("POST", "/files", data={"channel_id": "c"}, files={"files": ("a.txt", b"hi")})
+            assert req.headers["content-type"].startswith("multipart/form-data")
+            json_req = client.build_request("POST", "/posts", json={"a": 1})
+            assert json_req.headers["content-type"] == "application/json"
+        finally:
+            await client.aclose()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -201,6 +201,58 @@ class TestSharedClient:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_concurrent_wrappers_do_not_mix_tokens(self, mock_settings):
+        # Interleaved requests from two tenants through one shared pool must each
+        # carry their own token — the core guarantee of the shared-pool design.
+        import asyncio
+
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        seen_tokens: list[str | None] = []
+
+        def record(request: httpx.Request) -> httpx.Response:
+            seen_tokens.append(request.headers.get("Authorization"))
+            return httpx.Response(200, json={"id": "u1"})
+
+        respx.get("https://test.mattermost.com/api/v4/users/me").mock(side_effect=record)
+        settings = get_settings()
+        shared = create_http_client(settings)
+        try:
+            a = MattermostClient(settings, token="tok-A", http_client=shared)
+            b = MattermostClient(settings, token="tok-B", http_client=shared)
+
+            async def call(wrapper: MattermostClient) -> None:
+                async with wrapper.lifespan():
+                    await wrapper.get_me()
+
+            await asyncio.gather(call(a), call(b))
+
+            assert set(seen_tokens) == {"Bearer tok-A", "Bearer tok-B"}
+        finally:
+            await shared.aclose()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_caller_headers_merge_and_override_auth(self, mock_settings):
+        # Explicit headers passed by callers merge with the per-request auth header
+        # and win on key conflicts (see MattermostClient._request docstring).
+        from mcp_server_mattermost.config import get_settings
+
+        route = respx.get("https://test.mattermost.com/api/v4/users/me").mock(
+            return_value=httpx.Response(200, json={"id": "u1"}),
+        )
+        settings = get_settings()
+        client = MattermostClient(settings, token="base-token")
+        async with client.lifespan():
+            await client.get("/users/me", headers={"Authorization": "Bearer override", "X-Custom": "1"})
+
+        sent = route.calls[0].request.headers
+        assert sent["Authorization"] == "Bearer override"
+        assert sent["X-Custom"] == "1"
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_upload_sends_multipart_content_type(self, mock_settings, tmp_path):
         from mcp_server_mattermost.config import get_settings
 
@@ -2478,5 +2530,28 @@ class TestCreateHttpClient:
             assert req.headers["content-type"].startswith("multipart/form-data")
             json_req = client.build_request("POST", "/posts", json={"a": 1})
             assert json_req.headers["content-type"] == "application/json"
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_factory_client_does_not_persist_cookies(self, mock_settings):
+        # The shared pool is transport-only: a Set-Cookie returned to one tenant must
+        # never be stored and replayed on another tenant's request through the pool.
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        respx.get("https://test.mattermost.com/api/v4/first").mock(
+            return_value=httpx.Response(200, headers={"Set-Cookie": "MMAUTHTOKEN=session-A; Path=/"}, json={}),
+        )
+        second = respx.get("https://test.mattermost.com/api/v4/second").mock(
+            return_value=httpx.Response(200, json={}),
+        )
+        client = create_http_client(get_settings())
+        try:
+            await client.get("/first")
+            assert list(client.cookies.jar) == []
+            await client.get("/second")
+            assert "cookie" not in second.calls[0].request.headers
         finally:
             await client.aclose()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -93,35 +93,48 @@ class TestMattermostClientLifespan:
             assert str(client._client.base_url).rstrip("/") == "https://test.mattermost.com/api/v4"
 
     @pytest.mark.asyncio
-    async def test_lifespan_sets_auth_header(self, mock_settings):
+    async def test_lifespan_keeps_auth_out_of_default_headers(self, mock_settings):
+        """Security: the token is never stored in the httpx client's default headers."""
         from mcp_server_mattermost.config import get_settings
 
         settings = get_settings()
         client = MattermostClient(settings)
 
         async with client.lifespan():
-            assert "Authorization" in client._client.headers
-            assert client._client.headers["Authorization"] == "Bearer test-token-12345"
+            assert "authorization" not in client._client.headers
+        assert client._auth_headers == {"Authorization": "Bearer test-token-12345"}
 
     @pytest.mark.asyncio
-    async def test_lifespan_uses_token_override_in_header(self, mock_settings):
+    @respx.mock
+    async def test_token_override_sent_per_request(self, mock_settings):
         from mcp_server_mattermost.config import get_settings
 
+        route = respx.get("https://test.mattermost.com/api/v4/users/me").mock(
+            return_value=httpx.Response(200, json={"id": "u1"}),
+        )
         settings = get_settings()
         client = MattermostClient(settings, token="override-token")
 
         async with client.lifespan():
-            assert client._client.headers["Authorization"] == "Bearer override-token"
+            await client.get_me()
+
+        assert route.calls[0].request.headers["Authorization"] == "Bearer override-token"
 
     @pytest.mark.asyncio
-    async def test_lifespan_none_override_falls_back_to_settings_token(self, mock_settings):
+    @respx.mock
+    async def test_settings_token_sent_per_request_when_no_override(self, mock_settings):
         from mcp_server_mattermost.config import get_settings
 
+        route = respx.get("https://test.mattermost.com/api/v4/users/me").mock(
+            return_value=httpx.Response(200, json={"id": "u1"}),
+        )
         settings = get_settings()
         client = MattermostClient(settings, token=None)
 
         async with client.lifespan():
-            assert client._client.headers["Authorization"] == "Bearer test-token-12345"
+            await client.get_me()
+
+        assert route.calls[0].request.headers["Authorization"] == "Bearer test-token-12345"
 
     @pytest.mark.asyncio
     async def test_lifespan_warns_when_no_token(self, mock_settings_allow_http, caplog):
@@ -143,6 +156,68 @@ class TestMattermostClientLifespan:
             assert any("without authentication token" in record.message for record in caplog.records)
         finally:
             mm_logger.propagate = original_propagate
+
+
+class TestSharedClient:
+    @pytest.mark.asyncio
+    async def test_borrowed_client_not_closed_on_exit(self, mock_settings):
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        settings = get_settings()
+        shared = create_http_client(settings)
+        try:
+            client = MattermostClient(settings, http_client=shared)
+            async with client.lifespan():
+                assert client._client is shared
+            assert shared.is_closed is False
+        finally:
+            await shared.aclose()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_two_wrappers_share_client_isolate_tokens(self, mock_settings):
+        from mcp_server_mattermost.client import create_http_client
+        from mcp_server_mattermost.config import get_settings
+
+        route = respx.get("https://test.mattermost.com/api/v4/users/me").mock(
+            return_value=httpx.Response(200, json={"id": "u1"}),
+        )
+        settings = get_settings()
+        shared = create_http_client(settings)
+        try:
+            a = MattermostClient(settings, token="tok-A", http_client=shared)
+            b = MattermostClient(settings, token="tok-B", http_client=shared)
+            async with a.lifespan():
+                assert a._client is shared
+                await a.get_me()
+            async with b.lifespan():
+                assert b._client is shared
+                await b.get_me()
+            assert route.calls[0].request.headers["Authorization"] == "Bearer tok-A"
+            assert route.calls[1].request.headers["Authorization"] == "Bearer tok-B"
+        finally:
+            await shared.aclose()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_upload_sends_multipart_content_type(self, mock_settings, tmp_path):
+        from mcp_server_mattermost.config import get_settings
+
+        route = respx.post("https://test.mattermost.com/api/v4/files").mock(
+            return_value=httpx.Response(201, json={"file_infos": [{"id": "f1"}]}),
+        )
+        f = tmp_path / "a.txt"
+        f.write_bytes(b"hello")
+        settings = get_settings()
+        client = MattermostClient(settings)
+
+        async with client.lifespan():
+            await client.upload_file(channel_id="c1", file_path=str(f))
+
+        content_type = route.calls[0].request.headers["content-type"]
+        assert content_type.startswith("multipart/form-data")
+        assert route.calls[0].request.headers["Authorization"] == "Bearer test-token-12345"
 
 
 class TestMattermostClientResponseHandler:
@@ -2336,7 +2411,7 @@ class TestTokenOverride:
 
     @pytest.mark.asyncio
     async def test_lifespan_uses_override_token_in_headers(self, mock_settings: None) -> None:
-        """When token override is set, Authorization header uses override token."""
+        """When token override is set, the per-request Authorization header uses the override token."""
         import httpx
         import respx
 
@@ -2352,9 +2427,9 @@ class TestTokenOverride:
                 return_value=httpx.Response(200, json={"id": "u1"})
             )
             async with client.lifespan():
-                # Make a request to trigger the header to be checked
-                response = await client._client.get("/users/me")
-                assert response.status_code == 200
+                # Make a request through the client so per-request auth is applied
+                result = await client.get_me()
+                assert result["id"] == "u1"
 
         # Check the Authorization header was set with the override token
         assert route.calls[0].request.headers["authorization"] == "Bearer my-override-token"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -524,3 +524,43 @@ def test_http_host_origin_protection_rejects_unknown_value(monkeypatch):
 
     with pytest.raises(ValidationError):
         Settings()
+
+
+class TestPoolSettings:
+    def test_pool_defaults(self, monkeypatch):
+        from mcp_server_mattermost.config import Settings
+
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "t")
+        settings = Settings()
+
+        assert settings.max_connections == 100
+        assert settings.max_keepalive_connections == 20
+        assert settings.keepalive_expiry == 5.0
+
+    def test_pool_env_override(self, monkeypatch):
+        from mcp_server_mattermost.config import Settings
+
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "t")
+        monkeypatch.setenv("MATTERMOST_MAX_CONNECTIONS", "50")
+        monkeypatch.setenv("MATTERMOST_MAX_KEEPALIVE_CONNECTIONS", "10")
+        monkeypatch.setenv("MATTERMOST_KEEPALIVE_EXPIRY", "30")
+        settings = Settings()
+
+        assert settings.max_connections == 50
+        assert settings.max_keepalive_connections == 10
+        assert settings.keepalive_expiry == 30.0
+
+    def test_keepalive_cannot_exceed_max_connections(self, monkeypatch):
+        import pytest
+
+        from mcp_server_mattermost.config import Settings
+
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "t")
+        monkeypatch.setenv("MATTERMOST_MAX_CONNECTIONS", "10")
+        monkeypatch.setenv("MATTERMOST_MAX_KEEPALIVE_CONNECTIONS", "20")
+
+        with pytest.raises(ValueError, match="cannot exceed"):
+            Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -564,3 +564,15 @@ class TestPoolSettings:
 
         with pytest.raises(ValueError, match="cannot exceed"):
             Settings()
+
+    def test_keepalive_equal_to_max_connections_is_allowed(self, monkeypatch):
+        from mcp_server_mattermost.config import Settings
+
+        monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+        monkeypatch.setenv("MATTERMOST_TOKEN", "t")
+        monkeypatch.setenv("MATTERMOST_MAX_CONNECTIONS", "10")
+        monkeypatch.setenv("MATTERMOST_MAX_KEEPALIVE_CONNECTIONS", "10")
+
+        settings = Settings()
+
+        assert settings.max_keepalive_connections == settings.max_connections == 10

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -4,10 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_server_mattermost.constants import LIFESPAN_HTTP_CLIENT_KEY
+
 
 def _fake_context_with_pool():
     ctx = MagicMock()
-    ctx.lifespan_context = {"http_client": MagicMock()}
+    ctx.lifespan_context = {LIFESPAN_HTTP_CLIENT_KEY: MagicMock()}
     return ctx
 
 

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,8 +1,14 @@
 """Tests for dependency injection providers."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _fake_context_with_pool():
+    ctx = MagicMock()
+    ctx.lifespan_context = {"http_client": MagicMock()}
+    return ctx
 
 
 class TestGetClient:
@@ -12,10 +18,14 @@ class TestGetClient:
         from mcp_server_mattermost.client import MattermostClient
         from mcp_server_mattermost.deps import get_client
 
-        with patch("mcp_server_mattermost.deps.get_access_token", return_value=None):
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=None),
+            patch("mcp_server_mattermost.deps.get_context", return_value=_fake_context_with_pool()),
+        ):
             async with get_client() as client:
                 assert isinstance(client, MattermostClient)
                 assert client._token_override is None
+                assert client._borrowed_client is not None
 
     @pytest.mark.asyncio
     async def test_client_token_uses_access_token_claims(self, mock_settings_allow_http: None) -> None:
@@ -32,7 +42,10 @@ class TestGetClient:
             claims={"mattermost_token": "from-mattermost-token"},
         )
 
-        with patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token):
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token),
+            patch("mcp_server_mattermost.deps.get_context", return_value=_fake_context_with_pool()),
+        ):
             async with get_client() as client:
                 assert isinstance(client, MattermostClient)
                 assert client._token_override == "from-mattermost-token"
@@ -97,9 +110,28 @@ class TestGetClient:
             claims={"mattermost_token": "from-oauth-proxy"},
         )
 
-        with patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token):
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=mock_token),
+            patch("mcp_server_mattermost.deps.get_context", return_value=_fake_context_with_pool()),
+        ):
             async with get_client() as client:
                 assert isinstance(client, MattermostClient)
                 assert client._token_override == "from-oauth-proxy"
 
         get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_missing_pool_raises_runtime_error(self, mock_settings: None) -> None:
+        """get_client fails loud when the shared HTTP pool is not initialized."""
+        from mcp_server_mattermost.deps import get_client
+
+        empty_ctx = MagicMock()
+        empty_ctx.lifespan_context = {}
+
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=None),
+            patch("mcp_server_mattermost.deps.get_context", return_value=empty_ctx),
+            pytest.raises(RuntimeError, match="Shared HTTP client is not initialized"),
+        ):
+            async with get_client():
+                pass

--- a/tests/test_http_pool.py
+++ b/tests/test_http_pool.py
@@ -1,0 +1,58 @@
+"""Tests proving tool calls reuse one shared HTTP client."""
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client
+
+
+class TestSharedPool:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_series_of_tool_calls_creates_one_client(self, mock_settings, mocker):
+        from mcp_server_mattermost import server
+        from mcp_server_mattermost.server import mcp
+
+        team = {
+            "id": "tm1234567890123456789012",
+            "create_at": 1706400000000,
+            "update_at": 1706400000000,
+            "delete_at": 0,
+            "display_name": "My Team",
+            "name": "team",
+            "description": "",
+            "email": "",
+            "type": "O",
+            "allowed_domains": "",
+            "invite_id": "",
+            "allow_open_invite": False,
+        }
+        respx.get("https://test.mattermost.com/api/v4/users/me/teams").mock(
+            return_value=httpx.Response(200, json=[team]),
+        )
+        spy = mocker.spy(server, "create_http_client")
+
+        async with Client(mcp) as client:
+            await client.call_tool("list_teams", {})
+            await client.call_tool("list_teams", {})
+            await asyncio.gather(
+                client.call_tool("list_teams", {}),
+                client.call_tool("list_teams", {}),
+            )
+
+        assert spy.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_lifespan_closes_pool_on_shutdown(self, mock_settings, mocker):
+        from mcp_server_mattermost import server
+        from mcp_server_mattermost.server import mcp
+
+        spy = mocker.spy(server, "create_http_client")
+
+        async with Client(mcp):
+            pass
+
+        assert spy.call_count == 1
+        assert spy.spy_return.is_closed is True

--- a/tests/test_http_pool.py
+++ b/tests/test_http_pool.py
@@ -56,3 +56,24 @@ class TestSharedPool:
 
         assert spy.call_count == 1
         assert spy.spy_return.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_teardown_closes_auth_even_if_pool_close_raises(self, mock_settings, mocker):
+        # Shutdown must free the auth provider even if the pool's aclose() fails.
+        from mcp_server_mattermost import server
+        from mcp_server_mattermost.server import mcp
+
+        failing_client = mocker.MagicMock()
+        failing_client.aclose = mocker.AsyncMock(side_effect=RuntimeError("aclose boom"))
+        mocker.patch.object(server, "create_http_client", return_value=failing_client)
+
+        fake_auth = mocker.MagicMock()
+        fake_auth.close = mocker.AsyncMock()
+        mocker.patch.object(mcp, "auth", fake_auth)
+
+        with pytest.raises(RuntimeError, match="aclose boom"):
+            async with Client(mcp):
+                pass
+
+        failing_client.aclose.assert_awaited_once()
+        fake_auth.close.assert_awaited_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_server_mattermost.constants import LIFESPAN_HTTP_CLIENT_KEY
+
 
 class TestServerSetup:
     """Tests for FastMCP server instance."""
@@ -39,7 +41,7 @@ class TestDependencyProviders:
         from mcp_server_mattermost.deps import get_client
 
         fake_ctx = MagicMock()
-        fake_ctx.lifespan_context = {"http_client": MagicMock()}
+        fake_ctx.lifespan_context = {LIFESPAN_HTTP_CLIENT_KEY: MagicMock()}
 
         with (
             patch("mcp_server_mattermost.deps.get_access_token", return_value=None),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 """Tests for FastMCP server setup."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 
@@ -32,12 +34,19 @@ class TestDependencyProviders:
 
     @pytest.mark.asyncio
     async def test_get_client_yields_client(self, mock_settings: None) -> None:
-        """Test that get_client yields MattermostClient."""
+        """Test that get_client yields MattermostClient bound to the shared pool."""
         from mcp_server_mattermost.client import MattermostClient
         from mcp_server_mattermost.deps import get_client
 
-        async with get_client() as client:
-            assert isinstance(client, MattermostClient)
+        fake_ctx = MagicMock()
+        fake_ctx.lifespan_context = {"http_client": MagicMock()}
+
+        with (
+            patch("mcp_server_mattermost.deps.get_access_token", return_value=None),
+            patch("mcp_server_mattermost.deps.get_context", return_value=fake_ctx),
+        ):
+            async with get_client() as client:
+                assert isinstance(client, MattermostClient)
 
 
 class TestServerIntegration:


### PR DESCRIPTION
## What

Replace per-request `httpx.AsyncClient` creation with a single process-wide
connection pool, created once in the server lifespan and borrowed by every
tool call. The bearer token is sent per-request, so one pool safely serves
multiple users without mixing tokens.

## Why

Eliminates per-call TCP/TLS handshakes and TIME_WAIT churn on hot paths.

## Config

- `MATTERMOST_MAX_CONNECTIONS` (default 100)
- `MATTERMOST_MAX_KEEPALIVE_CONNECTIONS` (default 20)
- `MATTERMOST_KEEPALIVE_EXPIRY` (default 5.0s)

## Notes

- Fixes multipart uploads (dropped the default `Content-Type: application/json`).
- Shared pool is transport-only (cookie jar disabled) — no cross-tenant
  `Set-Cookie` replay.
- Shutdown closes the auth provider even if pool `aclose()` fails.

## Testing

`uv run ruff check / format / mypy / pytest` — 635 unit tests green.
Integration suite requires Docker (unaffected).