### PR TITLE
fix: default file_ids to empty list (closes #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `Post.file_ids` now defaults to an empty list instead of being a required field.
-  Mattermost tags the field `json:"file_ids,omitempty"` up to and including v10.4.0
-  (covering the 9.5 and 9.11 ESR lines), so posts without attachments omit the key
-  entirely and every response carrying a post failed to parse with
-  `ValidationError: file_ids Field required`. Affected `post_message`,
-  `update_message`, `pin_message`, `unpin_message`, `get_channel_messages`,
-  `search_messages` and `get_thread`. Servers on v10.5.0 or newer always send `[]`
-  and are unaffected either way. ([#27](https://github.com/cloud-ru-tech/mcp-server-mattermost/issues/27))
+- `Post.file_ids` defaults to an empty list — Mattermost ≤ v10.4.0 omits the key on posts
+  without attachments, which broke parsing in every tool that returns posts
+  ([#27](https://github.com/cloud-ru-tech/mcp-server-mattermost/issues/27))
 
 ### Security
 - Upgraded FastMCP to 3.4.4 — fixes CVE-2026-27124 (GHSA-rww4-4w9c-7733,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `Post.file_ids` now defaults to an empty list instead of being a required field.
+  Mattermost tags the field `json:"file_ids,omitempty"` up to and including v10.4.0
+  (covering the 9.5 and 9.11 ESR lines), so posts without attachments omit the key
+  entirely and every response carrying a post failed to parse with
+  `ValidationError: file_ids Field required`. Affected `post_message`,
+  `update_message`, `pin_message`, `unpin_message`, `get_channel_messages`,
+  `search_messages` and `get_thread`. Servers on v10.5.0 or newer always send `[]`
+  and are unaffected either way. ([#27](https://github.com/cloud-ru-tech/mcp-server-mattermost/issues/27))
+
 ### Security
 - Upgraded FastMCP to 3.4.4 — fixes CVE-2026-27124 (GHSA-rww4-4w9c-7733,
   missing consent check in the OAuth proxy callback), plus CVE-2026-32871

--- a/src/mcp_server_mattermost/models/post.py
+++ b/src/mcp_server_mattermost/models/post.py
@@ -20,7 +20,7 @@ class Post(MattermostResponse):
     message: str = Field(description="Post content (supports Markdown)")
     type: str = Field(description="Post type (empty for regular posts)")
     hashtags: str = Field(description="Space-separated hashtags")
-    file_ids: list[str] = Field(description="Attached file IDs")
+    file_ids: list[str] = Field(default_factory=list, description="Attached file IDs")
     pending_post_id: str = Field(description="Client-side pending ID")
     is_pinned: bool = Field(description="Whether post is pinned")
 

--- a/src/mcp_server_mattermost/models/post.py
+++ b/src/mcp_server_mattermost/models/post.py
@@ -6,7 +6,15 @@ from .base import MattermostResponse
 
 
 class Post(MattermostResponse):
-    """Message/post in Mattermost."""
+    """Message/post in Mattermost.
+
+    Note: ``file_ids`` must keep a default. Mattermost tags the field
+    ``json:"file_ids,omitempty"`` up to and including v10.4.0 (covering the 9.5 and
+    9.11 ESR lines), so posts without attachments omit the key entirely. The tag lost
+    ``omitempty`` in v10.5.0, which is why newer servers always send ``[]``.
+
+    See: https://github.com/mattermost/mattermost/blob/master/server/public/model/post.go
+    """
 
     id: str = Field(description="Unique post identifier")
     create_at: int = Field(description="Creation timestamp in milliseconds")

--- a/src/mcp_server_mattermost/models/post.py
+++ b/src/mcp_server_mattermost/models/post.py
@@ -6,15 +6,7 @@ from .base import MattermostResponse
 
 
 class Post(MattermostResponse):
-    """Message/post in Mattermost.
-
-    Note: ``file_ids`` must keep a default. Mattermost tags the field
-    ``json:"file_ids,omitempty"`` up to and including v10.4.0 (covering the 9.5 and
-    9.11 ESR lines), so posts without attachments omit the key entirely. The tag lost
-    ``omitempty`` in v10.5.0, which is why newer servers always send ``[]``.
-
-    See: https://github.com/mattermost/mattermost/blob/master/server/public/model/post.go
-    """
+    """Message/post in Mattermost."""
 
     id: str = Field(description="Unique post identifier")
     create_at: int = Field(description="Creation timestamp in milliseconds")

--- a/tests/models/test_post.py
+++ b/tests/models/test_post.py
@@ -4,7 +4,7 @@ from mcp_server_mattermost.models.post import Post, PostList, Reaction
 
 
 def test_post_parses_minimal():
-    """Test Post with every documented field present, as sent by Mattermost >= v10.5.0."""
+    """Test Post with all documented fields present."""
     data = {
         "id": "post123",
         "create_at": 1706400000000,
@@ -132,7 +132,7 @@ def test_post_list_truncated_can_be_set() -> None:
 
 
 def _post_without_file_ids(post_id: str = "post123") -> dict:
-    """Build a post payload as Mattermost <= v10.4.0 sends it: no file_ids key at all."""
+    """Build a post payload with no file_ids key."""
     return {
         "id": post_id,
         "create_at": 1706400000000,
@@ -152,18 +152,14 @@ def _post_without_file_ids(post_id: str = "post123") -> dict:
 
 
 def test_post_parses_without_file_ids_key() -> None:
-    """Servers <= v10.4.0 omit file_ids on posts with no attachments (see #27)."""
+    """file_ids may be absent from the payload (#27)."""
     post = Post(**_post_without_file_ids())
 
     assert post.file_ids == []
 
 
 def test_post_list_parses_nested_post_without_file_ids_key() -> None:
-    """The omitted key must not break nested parsing either.
-
-    Covers get_channel_messages, search_messages and get_thread, which all go
-    through PostList.
-    """
+    """An absent file_ids key must not break nested parsing either (#27)."""
     post_list = PostList(order=["post1"], posts={"post1": _post_without_file_ids("post1")})
 
     assert post_list.posts["post1"].file_ids == []

--- a/tests/models/test_post.py
+++ b/tests/models/test_post.py
@@ -4,7 +4,7 @@ from mcp_server_mattermost.models.post import Post, PostList, Reaction
 
 
 def test_post_parses_minimal():
-    """Test Post with minimal fields (all core fields required per Go source)."""
+    """Test Post with every documented field present, as sent by Mattermost >= v10.5.0."""
     data = {
         "id": "post123",
         "create_at": 1706400000000,
@@ -129,3 +129,51 @@ def test_post_list_truncated_can_be_set() -> None:
     """Tools may set truncated=True after detecting a cap hit."""
     pl = PostList(order=[], posts={}, truncated=True)
     assert pl.truncated is True
+
+
+def _post_without_file_ids(post_id: str = "post123") -> dict:
+    """Build a post payload as Mattermost <= v10.4.0 sends it: no file_ids key at all."""
+    return {
+        "id": post_id,
+        "create_at": 1706400000000,
+        "update_at": 1706400000000,
+        "delete_at": 0,
+        "edit_at": 0,
+        "user_id": "user456",
+        "channel_id": "ch789",
+        "root_id": "",
+        "original_id": "",
+        "message": "Hello world",
+        "type": "",
+        "hashtags": "",
+        "pending_post_id": "",
+        "is_pinned": False,
+    }
+
+
+def test_post_parses_without_file_ids_key() -> None:
+    """Servers <= v10.4.0 omit file_ids on posts with no attachments (see #27)."""
+    post = Post(**_post_without_file_ids())
+
+    assert post.file_ids == []
+
+
+def test_post_list_parses_nested_post_without_file_ids_key() -> None:
+    """The omitted key must not break nested parsing either.
+
+    Covers get_channel_messages, search_messages and get_thread, which all go
+    through PostList.
+    """
+    post_list = PostList(order=["post1"], posts={"post1": _post_without_file_ids("post1")})
+
+    assert post_list.posts["post1"].file_ids == []
+
+
+def test_post_file_ids_default_is_not_shared_between_instances() -> None:
+    """file_ids uses default_factory, so each Post gets its own list."""
+    first = Post(**_post_without_file_ids("post1"))
+    second = Post(**_post_without_file_ids("post2"))
+
+    first.file_ids.append("fileX")
+
+    assert second.file_ids == []

--- a/tests/test_tools/conftest.py
+++ b/tests/test_tools/conftest.py
@@ -55,12 +55,7 @@ def make_post_data(
     omit: tuple[str, ...] = (),
     **overrides,
 ) -> dict:
-    """Create full post mock data.
-
-    Most Post fields are always present in the JSON. `file_ids` is the exception:
-    Mattermost <= v10.4.0 tags it `omitempty` and drops the key on posts without
-    attachments. Pass `omit=("file_ids",)` to reproduce that shape.
-    """
+    """Create full post mock data. Pass `omit` to drop keys the server may not send."""
     data = {
         "id": post_id,
         "create_at": 1706400000000,

--- a/tests/test_tools/conftest.py
+++ b/tests/test_tools/conftest.py
@@ -52,13 +52,16 @@ def mock_client_rate_limited() -> AsyncMock:
 def make_post_data(
     post_id: str = "ps1234567890123456789012",
     message: str = "Hello, World!",
+    omit: tuple[str, ...] = (),
     **overrides,
 ) -> dict:
     """Create full post mock data.
 
-    Most Post fields are required (no omitempty per Mattermost Go source).
+    Most Post fields are always present in the JSON. `file_ids` is the exception:
+    Mattermost <= v10.4.0 tags it `omitempty` and drops the key on posts without
+    attachments. Pass `omit=("file_ids",)` to reproduce that shape.
     """
-    return {
+    data = {
         "id": post_id,
         "create_at": 1706400000000,
         "update_at": 1706400000000,
@@ -76,6 +79,9 @@ def make_post_data(
         "is_pinned": False,
         **overrides,
     }
+    for key in omit:
+        data.pop(key, None)
+    return data
 
 
 def make_post_list_data(

--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -71,11 +71,7 @@ class TestPostMessage:
         )
 
     async def test_post_message_when_server_omits_file_ids(self, mock_client: AsyncMock) -> None:
-        """Servers <= v10.4.0 drop the file_ids key on posts with no attachments (see #27).
-
-        Covers the Post(**data) path shared with update_message, pin_message and
-        unpin_message.
-        """
+        """post_message parses a post with no file_ids key (#27)."""
         mock_client.create_post.return_value = make_post_data(omit=("file_ids",))
 
         result = await messages.post_message(
@@ -111,10 +107,7 @@ class TestGetChannelMessages:
         assert result.truncated is False
 
     async def test_get_channel_messages_when_server_omits_file_ids(self, mock_client: AsyncMock) -> None:
-        """Nested posts missing the file_ids key must parse too (see #27).
-
-        Covers the PostList(**data) path shared with search_messages and get_thread.
-        """
+        """get_channel_messages parses nested posts with no file_ids key (#27)."""
         mock_client.get_posts.return_value = make_post_list_data(
             posts={"ps1": make_post_data(id="ps1", omit=("file_ids",))},
             order=["ps1"],

--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -70,6 +70,23 @@ class TestPostMessage:
             props=None,
         )
 
+    async def test_post_message_when_server_omits_file_ids(self, mock_client: AsyncMock) -> None:
+        """Servers <= v10.4.0 drop the file_ids key on posts with no attachments (see #27).
+
+        Covers the Post(**data) path shared with update_message, pin_message and
+        unpin_message.
+        """
+        mock_client.create_post.return_value = make_post_data(omit=("file_ids",))
+
+        result = await messages.post_message(
+            channel_id="ch1234567890123456789012",
+            message="Hello, World!",
+            client=mock_client,
+        )
+
+        assert isinstance(result, Post)
+        assert result.file_ids == []
+
 
 class TestGetChannelMessages:
     """Tests for get_channel_messages tool."""
@@ -92,6 +109,25 @@ class TestGetChannelMessages:
         assert isinstance(result, PostList)
         assert "ps1" in result.posts
         assert result.truncated is False
+
+    async def test_get_channel_messages_when_server_omits_file_ids(self, mock_client: AsyncMock) -> None:
+        """Nested posts missing the file_ids key must parse too (see #27).
+
+        Covers the PostList(**data) path shared with search_messages and get_thread.
+        """
+        mock_client.get_posts.return_value = make_post_list_data(
+            posts={"ps1": make_post_data(id="ps1", omit=("file_ids",))},
+            order=["ps1"],
+        )
+
+        result = await messages.get_channel_messages(
+            channel_id="ch1234567890123456789012",
+            page=0,
+            per_page=60,
+            client=mock_client,
+        )
+
+        assert result.posts["ps1"].file_ids == []
 
 
 class TestSearchMessages:


### PR DESCRIPTION
## What Changed

`Post.file_ids` was a required field with no default. Mattermost tags it
`json:"file_ids,omitempty"` up to and including **v10.4.0** — which covers the 9.5 and
9.11 ESR lines — so posts without attachments omit the key entirely and parsing failed
with `ValidationError: file_ids Field required`. The tag lost `omitempty` in **v10.5.0**,
which is why newer servers always send `[]` and never hit this.

The post is created successfully server-side; only the response parsing fails, which
makes it look like the message silently vanished.

Seven tools go through the affected code paths: `post_message`, `update_message`,
`pin_message`, `unpin_message` (`Post`) and `get_channel_messages`, `search_messages`,
`get_thread` (`PostList`).

**Fix** — `default_factory=list` on the field. Backward-compatible in both directions:
servers sending `[]` are unaffected, servers omitting the key now parse. This matches the
convention already used for the other `omitempty` fields in the model layer (`User`,
`FileInfo`, `ChannelBookmark`).

**Regression coverage** — the bug was invisible to CI because every fixture hardcodes
`"file_ids": []` and the integration suite runs against `release-11`. Added five tests
that fail without the default and pass with it:

- model layer: `Post` without the key, nested `PostList` without the key, and
  `default_factory` instance isolation (guards against a "simplification" to `default=[]`)
- tool layer: `post_message` (the `Post` path) and `get_channel_messages` (the `PostList` path)

`make_post_data` gained an `omit` parameter so the pre-v10.5 payload shape is expressible,
and the two fixture docstrings asserting that every core field is required were corrected —
that premise is what produced the bug.

## Related Issue

Fixes #27

## Checklist

- [x] Tests pass (`uv run pytest`) — 623 unit, 134 integration (2 environment skips)
- [x] Linter passes (`uv run ruff check src tests`)
- [x] Type checker passes (`uv run mypy src`)
- [x] Documentation updated (if applicable) — CHANGELOG `[Unreleased]` → `Fixed`

